### PR TITLE
feat: expose breeding NG rules API

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1604,6 +1604,115 @@
         ]
       }
     },
+    "/api/v1/breeding/ng-rules": {
+      "get": {
+        "operationId": "BreedingController_findNgRules",
+        "summary": "NGペアルール一覧の取得",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Breeding"
+        ]
+      },
+      "post": {
+        "operationId": "BreedingController_createNgRule",
+        "summary": "NGペアルールの作成",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateBreedingNgRuleDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Breeding"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/breeding/ng-rules/{id}": {
+      "patch": {
+        "operationId": "BreedingController_updateNgRule",
+        "summary": "NGペアルールの更新",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateBreedingNgRuleDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Breeding"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "BreedingController_removeNgRule",
+        "summary": "NGペアルールの削除",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Breeding"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
     "/api/v1/care/schedules": {
       "get": {
         "operationId": "CareController_findSchedules",
@@ -2305,6 +2414,76 @@
         ]
       },
       "UpdateBreedingDto": {
+        "type": "object",
+        "properties": {}
+      },
+      "CreateBreedingNgRuleDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "ルール名",
+            "example": "近親交配防止"
+          },
+          "description": {
+            "type": "string",
+            "description": "説明",
+            "example": "血統書付き同士の交配を避ける"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "TAG_COMBINATION",
+              "INDIVIDUAL_PROHIBITION",
+              "GENERATION_LIMIT"
+            ],
+            "example": "TAG_COMBINATION"
+          },
+          "active": {
+            "type": "boolean",
+            "description": "有効フラグ",
+            "default": true
+          },
+          "maleConditions": {
+            "description": "オス側のタグ条件",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "femaleConditions": {
+            "description": "メス側のタグ条件",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "maleNames": {
+            "description": "禁止するオス猫の名前",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "femaleNames": {
+            "description": "禁止するメス猫の名前",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "generationLimit": {
+            "type": "number",
+            "description": "世代制限 (親等)",
+            "minimum": 1
+          }
+        },
+        "required": [
+          "name",
+          "type"
+        ]
+      },
+      "UpdateBreedingNgRuleDto": {
         "type": "object",
         "properties": {}
       },

--- a/backend/prisma/migrations/20251011063613_add_breeding_ng_rules/migration.sql
+++ b/backend/prisma/migrations/20251011063613_add_breeding_ng_rules/migration.sql
@@ -1,0 +1,20 @@
+-- CreateEnum
+CREATE TYPE "public"."BreedingNgRuleType" AS ENUM ('TAG_COMBINATION', 'INDIVIDUAL_PROHIBITION', 'GENERATION_LIMIT');
+
+-- CreateTable
+CREATE TABLE "public"."breeding_ng_rules" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "type" "public"."BreedingNgRuleType" NOT NULL DEFAULT 'TAG_COMBINATION',
+    "male_conditions" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "female_conditions" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "male_names" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "female_names" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "generation_limit" INTEGER,
+    "active" BOOLEAN NOT NULL DEFAULT true,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "breeding_ng_rules_pkey" PRIMARY KEY ("id")
+);

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -189,6 +189,23 @@ model BreedingRecord {
   @@map("breeding_records")
 }
 
+model BreedingNgRule {
+  id               String             @id @default(uuid())
+  name             String
+  description      String?
+  type             BreedingNgRuleType @default(TAG_COMBINATION)
+  maleConditions   String[]           @default([]) @map("male_conditions")
+  femaleConditions String[]           @default([]) @map("female_conditions")
+  maleNames        String[]           @default([]) @map("male_names")
+  femaleNames      String[]           @default([]) @map("female_names")
+  generationLimit  Int?               @map("generation_limit")
+  active           Boolean            @default(true)
+  createdAt        DateTime           @default(now()) @map("created_at")
+  updatedAt        DateTime           @updatedAt @map("updated_at")
+
+  @@map("breeding_ng_rules")
+}
+
 model CareRecord {
   id          String   @id @default(uuid())
   catId       String   @map("cat_id")
@@ -377,6 +394,12 @@ enum BreedingStatus {
   IN_PROGRESS
   COMPLETED
   FAILED
+}
+
+enum BreedingNgRuleType {
+  TAG_COMBINATION
+  INDIVIDUAL_PROHIBITION
+  GENERATION_LIMIT
 }
 
 enum CareType {

--- a/backend/prisma/schema_prisma.txt
+++ b/backend/prisma/schema_prisma.txt
@@ -1,4 +1,4 @@
-// Prisma Schema - Last Updated: 2025-10-07T19:51:16.727Z
+// Prisma Schema - Last Updated: 2025-10-11T10:58:15.735Z
 // Auto-generated from schema.prisma
 
 // This is your Prisma schema file,
@@ -192,6 +192,23 @@ model BreedingRecord {
   @@map("breeding_records")
 }
 
+model BreedingNgRule {
+  id               String             @id @default(uuid())
+  name             String
+  description      String?
+  type             BreedingNgRuleType @default(TAG_COMBINATION)
+  maleConditions   String[]           @default([]) @map("male_conditions")
+  femaleConditions String[]           @default([]) @map("female_conditions")
+  maleNames        String[]           @default([]) @map("male_names")
+  femaleNames      String[]           @default([]) @map("female_names")
+  generationLimit  Int?               @map("generation_limit")
+  active           Boolean            @default(true)
+  createdAt        DateTime           @default(now()) @map("created_at")
+  updatedAt        DateTime           @updatedAt @map("updated_at")
+
+  @@map("breeding_ng_rules")
+}
+
 model CareRecord {
   id          String   @id @default(uuid())
   catId       String   @map("cat_id")
@@ -380,6 +397,12 @@ enum BreedingStatus {
   IN_PROGRESS
   COMPLETED
   FAILED
+}
+
+enum BreedingNgRuleType {
+  TAG_COMBINATION
+  INDIVIDUAL_PROHIBITION
+  GENERATION_LIMIT
 }
 
 enum CareType {

--- a/backend/src/breeding/breeding.controller.ts
+++ b/backend/src/breeding/breeding.controller.ts
@@ -23,7 +23,13 @@ import { JwtAuthGuard } from "../auth/jwt-auth.guard";
 
 
 import { BreedingService } from "./breeding.service";
-import { BreedingQueryDto, CreateBreedingDto, UpdateBreedingDto } from "./dto";
+import {
+  BreedingQueryDto,
+  CreateBreedingDto,
+  UpdateBreedingDto,
+  CreateBreedingNgRuleDto,
+  UpdateBreedingNgRuleDto,
+} from "./dto";
 
 @ApiTags("Breeding")
 @Controller("breeding")
@@ -67,5 +73,41 @@ export class BreedingController {
   @ApiParam({ name: "id" })
   remove(@Param("id") id: string) {
     return this.breedingService.remove(id);
+  }
+
+  @Get("ng-rules")
+  @ApiOperation({ summary: "NGペアルール一覧の取得" })
+  @ApiResponse({ status: HttpStatus.OK })
+  findNgRules() {
+    return this.breedingService.findNgRules();
+  }
+
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @Post("ng-rules")
+  @ApiOperation({ summary: "NGペアルールの作成" })
+  @ApiResponse({ status: HttpStatus.CREATED })
+  createNgRule(@Body() dto: CreateBreedingNgRuleDto) {
+    return this.breedingService.createNgRule(dto);
+  }
+
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @Patch("ng-rules/:id")
+  @ApiOperation({ summary: "NGペアルールの更新" })
+  @ApiResponse({ status: HttpStatus.OK })
+  @ApiParam({ name: "id" })
+  updateNgRule(@Param("id") id: string, @Body() dto: UpdateBreedingNgRuleDto) {
+    return this.breedingService.updateNgRule(id, dto);
+  }
+
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @Delete("ng-rules/:id")
+  @ApiOperation({ summary: "NGペアルールの削除" })
+  @ApiResponse({ status: HttpStatus.OK })
+  @ApiParam({ name: "id" })
+  removeNgRule(@Param("id") id: string) {
+    return this.breedingService.removeNgRule(id);
   }
 }

--- a/backend/src/breeding/breeding.service.ts
+++ b/backend/src/breeding/breeding.service.ts
@@ -6,14 +6,23 @@ import {
 
 import { PrismaService } from "../prisma/prisma.service";
 
-import { BreedingQueryDto, CreateBreedingDto, UpdateBreedingDto } from "./dto";
+import {
+  BreedingQueryDto,
+  CreateBreedingDto,
+  UpdateBreedingDto,
+  CreateBreedingNgRuleDto,
+  UpdateBreedingNgRuleDto,
+} from "./dto";
 import {
   BreedingWhereInput,
   CatWithGender,
   BreedingListResponse,
   BreedingCreateResponse,
   BreedingSuccessResponse,
+  BreedingNgRuleListResponse,
+  BreedingNgRuleResponse,
 } from "./types/breeding.types";
+import { Prisma } from "@prisma/client";
 
 @Injectable()
 export class BreedingService {
@@ -128,6 +137,70 @@ export class BreedingService {
 
   async remove(id: string): Promise<BreedingSuccessResponse> {
     await this.prisma.breedingRecord.delete({ where: { id } });
+    return { success: true };
+  }
+
+  async findNgRules(): Promise<BreedingNgRuleListResponse> {
+    const rules = await this.prisma.breedingNgRule.findMany({
+      orderBy: { createdAt: "desc" },
+    });
+
+    return { success: true, data: rules };
+  }
+
+  async createNgRule(dto: CreateBreedingNgRuleDto): Promise<BreedingNgRuleResponse> {
+    const rule = await this.prisma.breedingNgRule.create({
+      data: {
+        name: dto.name,
+        description: dto.description,
+        type: dto.type,
+        active: dto.active ?? true,
+        maleConditions: dto.maleConditions ?? [],
+        femaleConditions: dto.femaleConditions ?? [],
+        maleNames: dto.maleNames ?? [],
+        femaleNames: dto.femaleNames ?? [],
+        generationLimit: dto.generationLimit,
+      },
+    });
+
+    return { success: true, data: rule };
+  }
+
+  async updateNgRule(id: string, dto: UpdateBreedingNgRuleDto): Promise<BreedingNgRuleResponse> {
+    const data: Prisma.BreedingNgRuleUpdateInput = {
+      name: dto.name,
+      description: dto.description,
+      type: dto.type,
+      active: dto.active,
+      generationLimit: dto.generationLimit,
+    };
+
+    if (dto.maleConditions !== undefined) {
+      data.maleConditions = { set: dto.maleConditions };
+    }
+
+    if (dto.femaleConditions !== undefined) {
+      data.femaleConditions = { set: dto.femaleConditions };
+    }
+
+    if (dto.maleNames !== undefined) {
+      data.maleNames = { set: dto.maleNames };
+    }
+
+    if (dto.femaleNames !== undefined) {
+      data.femaleNames = { set: dto.femaleNames };
+    }
+
+    const rule = await this.prisma.breedingNgRule.update({
+      where: { id },
+      data,
+    });
+
+    return { success: true, data: rule };
+  }
+
+  async removeNgRule(id: string): Promise<BreedingSuccessResponse> {
+    await this.prisma.breedingNgRule.delete({ where: { id } });
     return { success: true };
   }
 }

--- a/backend/src/breeding/dto/create-breeding-ng-rule.dto.ts
+++ b/backend/src/breeding/dto/create-breeding-ng-rule.dto.ts
@@ -1,0 +1,68 @@
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
+import {
+  ArrayNotEmpty,
+  IsArray,
+  IsBoolean,
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsString,
+  Min,
+  ValidateIf,
+} from "class-validator";
+import { BreedingNgRuleType } from "@prisma/client";
+
+export class CreateBreedingNgRuleDto {
+  @ApiProperty({ description: "ルール名", example: "近親交配防止" })
+  @IsString()
+  name!: string;
+
+  @ApiPropertyOptional({ description: "説明", example: "血統書付き同士の交配を避ける" })
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @ApiProperty({ enum: BreedingNgRuleType, example: BreedingNgRuleType.TAG_COMBINATION })
+  @IsEnum(BreedingNgRuleType)
+  type!: BreedingNgRuleType;
+
+  @ApiPropertyOptional({ description: "有効フラグ", default: true })
+  @IsOptional()
+  @IsBoolean()
+  active?: boolean;
+
+  @ApiPropertyOptional({ description: "オス側のタグ条件", type: [String] })
+  @ValidateIf((dto) => dto.type === BreedingNgRuleType.TAG_COMBINATION)
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsString({ each: true })
+  maleConditions?: string[];
+
+  @ApiPropertyOptional({ description: "メス側のタグ条件", type: [String] })
+  @ValidateIf((dto) => dto.type === BreedingNgRuleType.TAG_COMBINATION)
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsString({ each: true })
+  femaleConditions?: string[];
+
+  @ApiPropertyOptional({ description: "禁止するオス猫の名前", type: [String] })
+  @ValidateIf((dto) => dto.type === BreedingNgRuleType.INDIVIDUAL_PROHIBITION)
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsString({ each: true })
+  maleNames?: string[];
+
+  @ApiPropertyOptional({ description: "禁止するメス猫の名前", type: [String] })
+  @ValidateIf((dto) => dto.type === BreedingNgRuleType.INDIVIDUAL_PROHIBITION)
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsString({ each: true })
+  femaleNames?: string[];
+
+  @ApiPropertyOptional({ description: "世代制限 (親等)", minimum: 1 })
+  @ValidateIf((dto) => dto.type === BreedingNgRuleType.GENERATION_LIMIT)
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  generationLimit?: number;
+}

--- a/backend/src/breeding/dto/index.ts
+++ b/backend/src/breeding/dto/index.ts
@@ -1,3 +1,5 @@
 export * from "./create-breeding.dto";
 export * from "./update-breeding.dto";
 export * from "./breeding-query.dto";
+export * from "./create-breeding-ng-rule.dto";
+export * from "./update-breeding-ng-rule.dto";

--- a/backend/src/breeding/dto/update-breeding-ng-rule.dto.ts
+++ b/backend/src/breeding/dto/update-breeding-ng-rule.dto.ts
@@ -1,0 +1,5 @@
+import { PartialType } from "@nestjs/mapped-types";
+
+import { CreateBreedingNgRuleDto } from "./create-breeding-ng-rule.dto";
+
+export class UpdateBreedingNgRuleDto extends PartialType(CreateBreedingNgRuleDto) {}

--- a/backend/src/breeding/types/breeding.types.ts
+++ b/backend/src/breeding/types/breeding.types.ts
@@ -1,4 +1,4 @@
-import { Prisma } from '@prisma/client';
+import type { Prisma, BreedingNgRuleType } from '@prisma/client';
 
 export interface BreedingWhereInput {
   femaleId?: string;
@@ -42,4 +42,29 @@ export interface BreedingCreateResponse {
 
 export interface BreedingSuccessResponse {
   success: true;
+}
+
+export interface BreedingNgRule {
+  id: string;
+  name: string;
+  description: string | null;
+  type: BreedingNgRuleType;
+  maleConditions: string[];
+  femaleConditions: string[];
+  maleNames: string[];
+  femaleNames: string[];
+  generationLimit: number | null;
+  active: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface BreedingNgRuleListResponse {
+  success: true;
+  data: BreedingNgRule[];
+}
+
+export interface BreedingNgRuleResponse {
+  success: true;
+  data: BreedingNgRule;
 }

--- a/backend/test/breeding-ng-rules.e2e-spec.ts
+++ b/backend/test/breeding-ng-rules.e2e-spec.ts
@@ -1,0 +1,113 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+
+import { AppModule } from '../src/app.module';
+import { createTestApp } from './utils/create-test-app';
+
+describe('Breeding NG Rules API (e2e)', () => {
+  let app: INestApplication;
+  let authToken: string;
+  let createdRuleId: string;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = await createTestApp(moduleRef);
+
+    const email = `breeding_ng_rules_${Date.now()}@example.com`;
+    const password = 'NgRulesTest123!';
+
+    await request(app.getHttpServer())
+      .post('/api/v1/auth/register')
+      .send({ email, password })
+      .expect(201);
+
+    const loginRes = await request(app.getHttpServer())
+      .post('/api/v1/auth/login')
+      .send({ email, password })
+      .expect(201);
+
+    authToken = loginRes.body.data.access_token;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should create a new NG rule', async () => {
+    const res = await request(app.getHttpServer())
+      .post('/api/v1/breeding/ng-rules')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({
+        name: '同一タグ禁止',
+        description: '同じタグ同士の交配を禁止',
+        type: 'TAG_COMBINATION',
+        maleConditions: ['Champion'],
+        femaleConditions: ['Champion'],
+      })
+      .expect(201);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toMatchObject({
+      name: '同一タグ禁止',
+      type: 'TAG_COMBINATION',
+      active: true,
+    });
+
+    createdRuleId = res.body.data.id;
+    expect(createdRuleId).toBeDefined();
+  });
+
+  it('should list NG rules including the created one', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/api/v1/breeding/ng-rules')
+      .set('Authorization', `Bearer ${authToken}`)
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+    const found = res.body.data.find((rule: { id: string }) => rule.id === createdRuleId);
+    expect(found).toBeDefined();
+  });
+
+  it('should update an existing NG rule', async () => {
+    const res = await request(app.getHttpServer())
+      .patch(`/api/v1/breeding/ng-rules/${createdRuleId}`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({
+        description: '条件を更新',
+        maleConditions: ['GrandChampion'],
+        femaleConditions: ['Champion'],
+        active: false,
+      })
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toMatchObject({
+      id: createdRuleId,
+      description: '条件を更新',
+      maleConditions: ['GrandChampion'],
+      femaleConditions: ['Champion'],
+      active: false,
+    });
+  });
+
+  it('should delete the NG rule', async () => {
+    const res = await request(app.getHttpServer())
+      .delete(`/api/v1/breeding/ng-rules/${createdRuleId}`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+
+    const listRes = await request(app.getHttpServer())
+      .get('/api/v1/breeding/ng-rules')
+      .set('Authorization', `Bearer ${authToken}`)
+      .expect(200);
+
+    const found = listRes.body.data.find((rule: { id: string }) => rule.id === createdRuleId);
+    expect(found).toBeUndefined();
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,16 +19,19 @@
     "@mantine/dates": "^8.2.2",
     "@mantine/form": "^8.2.2",
     "@mantine/hooks": "^8.2.2",
-    "@mantine/notifications": "^8.2.2",
+  "@mantine/notifications": "^8.2.2",
+  "@hookform/resolvers": "^3.9.0",
     "@sentry/nextjs": "^8.26.0",
     "@tabler/icons-react": "^3.34.1",
-    "@tanstack/react-query": "^5.90.2",
+  "@tanstack/react-query": "^5.90.2",
+  "react-hook-form": "^7.53.0",
     "dayjs": "^1.11.13",
     "next": "15.5.3",
     "openapi-typescript": "^7.9.1",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "zustand": "^5.0.8"
+    "zustand": "^5.0.8",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",

--- a/frontend/src/components/TagSelector.tsx
+++ b/frontend/src/components/TagSelector.tsx
@@ -40,6 +40,7 @@ interface TagSelectorProps {
   placeholder?: string;
   label?: string;
   categories?: TagCategory[];
+  disabled?: boolean;
 }
 
 // デフォルトのタグカテゴリ（実際の実装では外部から取得）
@@ -83,10 +84,17 @@ export default function TagSelector({
   onChange, 
   placeholder = "タグを選択", 
   label = "タグ",
-  categories = defaultCategories 
+  categories = defaultCategories,
+  disabled = false,
 }: TagSelectorProps) {
   const [opened, { open, close }] = useDisclosure(false);
   const [allTags, setAllTags] = useState<Tag[]>([]);
+
+  useEffect(() => {
+    if (disabled && opened) {
+      close();
+    }
+  }, [disabled, opened, close]);
 
   useEffect(() => {
     // 全カテゴリからタグを抽出
@@ -164,6 +172,7 @@ export default function TagSelector({
           variant="light" 
           leftSection={<IconPlus size={12} />}
           onClick={open}
+          disabled={disabled}
         >
           カテゴリ別選択
         </Button>
@@ -176,6 +185,7 @@ export default function TagSelector({
         onChange={onChange}
         searchable
         clearable
+        disabled={disabled}
         renderOption={({ option }) => {
           const tag = allTags.find(t => t.id === option.value);
           return (

--- a/frontend/src/lib/api/generated/schema.ts
+++ b/frontend/src/lib/api/generated/schema.ts
@@ -479,6 +479,42 @@ export type paths = {
         patch: operations["BreedingController_update"];
         trace?: never;
     };
+    "/api/v1/breeding/ng-rules": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** NGペアルール一覧の取得 */
+        get: operations["BreedingController_findNgRules"];
+        put?: never;
+        /** NGペアルールの作成 */
+        post: operations["BreedingController_createNgRule"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/breeding/ng-rules/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** NGペアルールの削除 */
+        delete: operations["BreedingController_removeNgRule"];
+        options?: never;
+        head?: never;
+        /** NGペアルールの更新 */
+        patch: operations["BreedingController_updateNgRule"];
+        trace?: never;
+    };
     "/api/v1/care/schedules": {
         parameters: {
             query?: never;
@@ -800,6 +836,39 @@ export type components = {
             notes?: string;
         };
         UpdateBreedingDto: Record<string, never>;
+        CreateBreedingNgRuleDto: {
+            /**
+             * @description ルール名
+             * @example 近親交配防止
+             */
+            name: string;
+            /**
+             * @description 説明
+             * @example 血統書付き同士の交配を避ける
+             */
+            description?: string;
+            /**
+             * @example TAG_COMBINATION
+             * @enum {string}
+             */
+            type: "TAG_COMBINATION" | "INDIVIDUAL_PROHIBITION" | "GENERATION_LIMIT";
+            /**
+             * @description 有効フラグ
+             * @default true
+             */
+            active: boolean;
+            /** @description オス側のタグ条件 */
+            maleConditions?: string[];
+            /** @description メス側のタグ条件 */
+            femaleConditions?: string[];
+            /** @description 禁止するオス猫の名前 */
+            maleNames?: string[];
+            /** @description 禁止するメス猫の名前 */
+            femaleNames?: string[];
+            /** @description 世代制限 (親等) */
+            generationLimit?: number;
+        };
+        UpdateBreedingNgRuleDto: Record<string, never>;
         CreateCareScheduleDto: {
             /**
              * @description 猫ID
@@ -2050,6 +2119,86 @@ export interface operations {
         requestBody: {
             content: {
                 "application/json": components["schemas"]["UpdateBreedingDto"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    BreedingController_findNgRules: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    BreedingController_createNgRule: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateBreedingNgRuleDto"];
+            };
+        };
+        responses: {
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    BreedingController_removeNgRule: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    BreedingController_updateNgRule: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateBreedingNgRuleDto"];
             };
         };
         responses: {

--- a/frontend/src/lib/api/hooks/query-key-factory.ts
+++ b/frontend/src/lib/api/hooks/query-key-factory.ts
@@ -8,13 +8,13 @@ export type DomainQueryKeyFactory<Identifier = string, Filters = Record<string, 
   list: (filters?: Filters) => readonly [string, 'list', Filters | undefined];
   details: () => readonly [string, 'detail'];
   detail: (id: Identifier) => readonly [string, 'detail', Identifier];
-  extras?: Record<string, (...args: never[]) => readonly unknown[]>;
+  extras?: Record<string, (...args: unknown[]) => readonly unknown[]>;
 };
 
 export function createDomainQueryKeys<Identifier = string, Filters = Record<string, unknown>>(
   domain: string,
   options?: {
-    extras?: Record<string, (...args: never[]) => readonly unknown[]>;
+    extras?: Record<string, (...args: unknown[]) => readonly unknown[]>;
   },
 ): DomainQueryKeyFactory<Identifier, Filters> {
   const base = [domain] as const;
@@ -31,7 +31,7 @@ export function createDomainQueryKeys<Identifier = string, Filters = Record<stri
     factory.extras = Object.fromEntries(
       Object.entries(options.extras).map(([key, builder]) => [
         key,
-        (...args: never[]) => [...base, key, ...builder(...args)] as const,
+        (...args: unknown[]) => [...base, key, ...builder(...args)] as const,
       ]),
     );
   }

--- a/frontend/src/lib/api/hooks/use-breeding.ts
+++ b/frontend/src/lib/api/hooks/use-breeding.ts
@@ -1,0 +1,317 @@
+/**
+ * 交配管理APIフック
+ */
+
+import { useMutation, useQuery, useQueryClient, type UseQueryOptions } from '@tanstack/react-query';
+import { notifications } from '@mantine/notifications';
+import {
+  apiClient,
+  apiRequest,
+  type ApiPathParams,
+  type ApiQueryParams,
+  type ApiRequestBody,
+  type ApiResponse,
+} from '../client';
+import { createDomainQueryKeys } from './query-key-factory';
+
+export type BreedingStatus = 'PLANNED' | 'IN_PROGRESS' | 'COMPLETED' | 'FAILED';
+
+export interface BreedingRecord {
+  id: string;
+  maleId: string;
+  femaleId: string;
+  breedingDate: string;
+  expectedDueDate?: string | null;
+  actualDueDate?: string | null;
+  numberOfKittens?: number | null;
+  notes?: string | null;
+  status: BreedingStatus;
+  recordedBy: string;
+  createdAt: string;
+  updatedAt: string;
+  male?: { id: string; name: string | null } | null;
+  female?: { id: string; name: string | null } | null;
+}
+
+export interface BreedingListMeta {
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+export type GetBreedingParams = ApiQueryParams<'/breeding', 'get'>;
+
+export interface BreedingListResponse {
+  success: boolean;
+  data?: BreedingRecord[];
+  meta?: BreedingListMeta;
+  message?: string;
+  error?: string;
+}
+
+export type CreateBreedingRequest = ApiRequestBody<'/breeding', 'post'>;
+export type UpdateBreedingRequest = Partial<CreateBreedingRequest>;
+
+const breedingKeys = createDomainQueryKeys<string, GetBreedingParams>('breeding');
+
+export type BreedingNgRuleType = 'TAG_COMBINATION' | 'INDIVIDUAL_PROHIBITION' | 'GENERATION_LIMIT';
+
+export interface BreedingNgRule {
+  id: string;
+  name: string;
+  description: string | null;
+  type: BreedingNgRuleType;
+  maleConditions: string[];
+  femaleConditions: string[];
+  maleNames: string[];
+  femaleNames: string[];
+  generationLimit: number | null;
+  active: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface BreedingNgRuleFilter {
+  active?: boolean;
+  type?: BreedingNgRuleType;
+  search?: string;
+}
+
+export type CreateBreedingNgRuleRequest = {
+  name: string;
+  description?: string;
+  type: BreedingNgRuleType;
+  active?: boolean;
+  maleConditions?: string[];
+  femaleConditions?: string[];
+  maleNames?: string[];
+  femaleNames?: string[];
+  generationLimit?: number;
+};
+
+export type UpdateBreedingNgRuleRequest = Partial<CreateBreedingNgRuleRequest>;
+
+export type BreedingNgRuleListResponse = ApiResponse<BreedingNgRule[]>;
+export type BreedingNgRuleResponse = ApiResponse<BreedingNgRule>;
+
+const breedingNgRuleKeys = createDomainQueryKeys<string, BreedingNgRuleFilter>('breeding-ng-rules', {
+  extras: {
+    filterState: (...args: unknown[]) => {
+      const [filters] = args as [BreedingNgRuleFilter | undefined];
+      return [filters ?? {}] as const;
+    },
+    type: (...args: unknown[]) => {
+      const [type] = args as [BreedingNgRuleType | 'ALL' | undefined];
+      return [type ?? 'ALL'] as const;
+    },
+    search: (...args: unknown[]) => {
+      const [keyword] = args as [string | undefined];
+      return [keyword ?? ''] as const;
+    },
+  },
+});
+
+export { breedingKeys };
+export { breedingNgRuleKeys };
+
+export function useGetBreedingRecords(
+  params: GetBreedingParams = {},
+  options?: Omit<UseQueryOptions<BreedingListResponse>, 'queryKey' | 'queryFn'>,
+) {
+  return useQuery({
+    queryKey: breedingKeys.list(params),
+    queryFn: () =>
+      apiClient.get('/breeding', {
+        query: params,
+      }) as Promise<BreedingListResponse>,
+    ...options,
+  });
+}
+
+export function useCreateBreedingRecord() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: CreateBreedingRequest) =>
+      apiClient.post('/breeding', {
+        body: payload,
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: breedingKeys.lists() });
+      notifications.show({
+        title: '交配記録を登録しました',
+        message: '交配スケジュールを管理画面に反映しました。',
+        color: 'teal',
+      });
+    },
+    onError: (error: Error) => {
+      notifications.show({
+        title: '交配記録の登録に失敗しました',
+        message: error.message ?? '入力内容をご確認の上、再度お試しください。',
+        color: 'red',
+      });
+    },
+  });
+}
+
+export function useUpdateBreedingRecord(
+  id: string,
+) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: UpdateBreedingRequest) =>
+      apiClient.patch('/breeding/{id}', {
+        pathParams: { id } as ApiPathParams<'/breeding/{id}', 'patch'>,
+        body: payload as ApiRequestBody<'/breeding/{id}', 'patch'>,
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: breedingKeys.lists() });
+      notifications.show({
+        title: '交配記録を更新しました',
+        message: '最新の情報に更新されました。',
+        color: 'teal',
+      });
+    },
+    onError: (error: Error) => {
+      notifications.show({
+        title: '交配記録の更新に失敗しました',
+        message: error.message ?? '時間をおいて再度お試しください。',
+        color: 'red',
+      });
+    },
+  });
+}
+
+export function useDeleteBreedingRecord() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (recordId: string) =>
+      apiClient.delete('/breeding/{id}', {
+        pathParams: { id: recordId } as ApiPathParams<'/breeding/{id}', 'delete'>,
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: breedingKeys.lists() });
+      notifications.show({
+        title: '交配記録を削除しました',
+        message: 'リストから該当レコードを削除しました。',
+        color: 'teal',
+      });
+    },
+    onError: (error: Error) => {
+      notifications.show({
+        title: '交配記録の削除に失敗しました',
+        message: error.message ?? '時間をおいて再度お試しください。',
+        color: 'red',
+      });
+    },
+  });
+}
+
+const NG_RULES_ENDPOINT = '/breeding/ng-rules';
+
+function buildNgRuleEndpoint(id?: string): string {
+  if (!id) {
+    return NG_RULES_ENDPOINT;
+  }
+
+  return `${NG_RULES_ENDPOINT}/${id}`;
+}
+
+export function useGetBreedingNgRules(
+  options?: Omit<UseQueryOptions<BreedingNgRuleListResponse, Error, BreedingNgRuleListResponse>, 'queryKey' | 'queryFn'>,
+) {
+  return useQuery({
+    queryKey: breedingNgRuleKeys.lists(),
+    queryFn: () => apiRequest<BreedingNgRule[]>(buildNgRuleEndpoint(), { method: 'GET' }),
+    staleTime: 60 * 1000,
+    ...options,
+  });
+}
+
+export function useCreateBreedingNgRule() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: CreateBreedingNgRuleRequest) =>
+      apiRequest<BreedingNgRule>(buildNgRuleEndpoint(), {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: breedingNgRuleKeys.lists() });
+      notifications.show({
+        title: 'NGルールを登録しました',
+        message: '交配NGルールを追加しました。',
+        color: 'teal',
+      });
+    },
+    onError: (error: Error) => {
+      notifications.show({
+        title: 'NGルールの登録に失敗しました',
+        message: error.message ?? '時間をおいて再度お試しください。',
+        color: 'red',
+      });
+    },
+  });
+}
+
+export interface UpdateBreedingNgRuleVariables {
+  id: string;
+  payload: UpdateBreedingNgRuleRequest;
+}
+
+export function useUpdateBreedingNgRule() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, payload }: UpdateBreedingNgRuleVariables) =>
+      apiRequest<BreedingNgRule>(buildNgRuleEndpoint(id), {
+        method: 'PATCH',
+        body: JSON.stringify(payload),
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: breedingNgRuleKeys.lists() });
+      notifications.show({
+        title: 'NGルールを更新しました',
+        message: '交配NGルールの内容を更新しました。',
+        color: 'teal',
+      });
+    },
+    onError: (error: Error) => {
+      notifications.show({
+        title: 'NGルールの更新に失敗しました',
+        message: error.message ?? '時間をおいて再度お試しください。',
+        color: 'red',
+      });
+    },
+  });
+}
+
+export function useDeleteBreedingNgRule() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (ruleId: string) =>
+      apiRequest<unknown>(buildNgRuleEndpoint(ruleId), {
+        method: 'DELETE',
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: breedingNgRuleKeys.lists() });
+      notifications.show({
+        title: 'NGルールを削除しました',
+        message: '交配NGルールを削除しました。',
+        color: 'teal',
+      });
+    },
+    onError: (error: Error) => {
+      notifications.show({
+        title: 'NGルールの削除に失敗しました',
+        message: error.message ?? '時間をおいて再度お試しください。',
+        color: 'red',
+      });
+    },
+  });
+}

--- a/frontend/src/lib/api/hooks/use-care.ts
+++ b/frontend/src/lib/api/hooks/use-care.ts
@@ -1,0 +1,123 @@
+/**
+ * ケアスケジュールAPIフック
+ */
+
+import { useMutation, useQuery, useQueryClient, type UseQueryOptions } from '@tanstack/react-query';
+import { notifications } from '@mantine/notifications';
+import { apiClient, type ApiPathParams, type ApiQueryParams, type ApiRequestBody } from '../client';
+import { createDomainQueryKeys } from './query-key-factory';
+
+export type CareType =
+  | 'VACCINATION'
+  | 'HEALTH_CHECK'
+  | 'GROOMING'
+  | 'DENTAL_CARE'
+  | 'MEDICATION'
+  | 'SURGERY'
+  | 'OTHER';
+
+export interface CareSchedule {
+  id: string;
+  title: string;
+  description?: string | null;
+  scheduleDate: string;
+  scheduleType: 'CARE' | string;
+  status: 'PENDING' | 'IN_PROGRESS' | 'COMPLETED' | 'CANCELLED';
+  priority: 'LOW' | 'MEDIUM' | 'HIGH' | 'URGENT';
+  catId?: string | null;
+  assignedTo: string;
+  createdAt: string;
+  updatedAt: string;
+  cat?: { id: string; name: string } | null;
+}
+
+export interface CareScheduleMeta {
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+export type GetCareSchedulesParams = ApiQueryParams<'/care/schedules', 'get'>;
+
+export interface CareScheduleListResponse {
+  success: boolean;
+  data?: CareSchedule[];
+  meta?: CareScheduleMeta;
+  message?: string;
+  error?: string;
+}
+
+export type CreateCareScheduleRequest = ApiRequestBody<'/care/schedules', 'post'>;
+export type CompleteCareScheduleRequest = ApiRequestBody<'/care/schedules/{id}/complete', 'patch'>;
+
+const careScheduleKeys = createDomainQueryKeys<string, GetCareSchedulesParams>('care-schedules');
+
+export { careScheduleKeys };
+
+export function useGetCareSchedules(
+  params: GetCareSchedulesParams = {},
+  options?: Omit<UseQueryOptions<CareScheduleListResponse>, 'queryKey' | 'queryFn'>,
+) {
+  return useQuery({
+    queryKey: careScheduleKeys.list(params),
+    queryFn: () =>
+      apiClient.get('/care/schedules', {
+        query: params,
+      }) as Promise<CareScheduleListResponse>,
+    ...options,
+  });
+}
+
+export function useAddCareSchedule() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: CreateCareScheduleRequest) =>
+      apiClient.post('/care/schedules', {
+        body: payload,
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: careScheduleKeys.lists() });
+      notifications.show({
+        title: 'ケア予定を登録しました',
+        message: 'ケアスケジュールを追加しました。',
+        color: 'teal',
+      });
+    },
+    onError: (error: Error) => {
+      notifications.show({
+        title: 'ケア予定の登録に失敗しました',
+        message: error.message ?? '時間をおいて再度お試しください。',
+        color: 'red',
+      });
+    },
+  });
+}
+
+export function useCompleteCareSchedule(id: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: CompleteCareScheduleRequest) =>
+      apiClient.patch('/care/schedules/{id}/complete', {
+        pathParams: { id } as ApiPathParams<'/care/schedules/{id}/complete', 'patch'>,
+        body: payload,
+      }),
+    onSuccess: (_response) => {
+      void queryClient.invalidateQueries({ queryKey: careScheduleKeys.lists() });
+      notifications.show({
+        title: 'ケア予定を完了しました',
+        message: '完了履歴に記録しました。',
+        color: 'teal',
+      });
+    },
+    onError: (error: Error) => {
+      notifications.show({
+        title: 'ケア完了処理に失敗しました',
+        message: error.message ?? '入力内容をご確認ください。',
+        color: 'red',
+      });
+    },
+  });
+}

--- a/frontend/src/lib/api/hooks/use-pedigrees.ts
+++ b/frontend/src/lib/api/hooks/use-pedigrees.ts
@@ -1,0 +1,241 @@
+/**
+ * 血統書管理APIフック
+ */
+
+import { useMutation, useQuery, useQueryClient, type UseQueryOptions } from '@tanstack/react-query';
+import { notifications } from '@mantine/notifications';
+import { apiClient, type ApiPathParams, type ApiQueryParams, type ApiRequestBody } from '../client';
+import { createDomainQueryKeys } from './query-key-factory';
+
+export interface PedigreeRecord {
+  id: string;
+  pedigreeId: string;
+  catName?: string | null;
+  title?: string | null;
+  genderCode?: number | null;
+  eyeColor?: string | null;
+  breedCode?: number | null;
+  coatColorCode?: number | null;
+  birthDate?: string | null;
+  breederName?: string | null;
+  ownerName?: string | null;
+  registrationDate?: string | null;
+  createdAt?: string;
+  updatedAt?: string;
+  [key: string]: unknown;
+}
+
+export interface PedigreeListMeta {
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+export type GetPedigreesParams = ApiQueryParams<'/pedigrees', 'get'>;
+
+export interface PedigreeListResponse {
+  success: boolean;
+  data?: PedigreeRecord[];
+  meta?: PedigreeListMeta;
+  message?: string;
+  error?: string;
+}
+
+export type CreatePedigreeRequest = ApiRequestBody<'/pedigrees', 'post'>;
+export type UpdatePedigreeRequest = ApiRequestBody<'/pedigrees/{id}', 'patch'>;
+
+const basePedigreeKeys = createDomainQueryKeys<string, GetPedigreesParams>('pedigrees');
+
+export const pedigreeKeys = {
+  ...basePedigreeKeys,
+  byNumber: (pedigreeId: string) => [...basePedigreeKeys.all, 'by-number', pedigreeId] as const,
+  family: (id: string, generations?: number) =>
+    [...basePedigreeKeys.all, 'family', id, generations ?? 'default'] as const,
+  familyTree: (id: string) => [...basePedigreeKeys.all, 'family-tree', id] as const,
+  descendants: (id: string) => [...basePedigreeKeys.all, 'descendants', id] as const,
+};
+
+export function useGetPedigrees(
+  params: GetPedigreesParams = {},
+  options?: Omit<UseQueryOptions<PedigreeListResponse>, 'queryKey' | 'queryFn'>,
+) {
+  return useQuery({
+    queryKey: pedigreeKeys.list(params),
+    queryFn: () =>
+      apiClient.get('/pedigrees', {
+        query: params,
+      }) as Promise<PedigreeListResponse>,
+    ...options,
+  });
+}
+
+export function useGetPedigree(
+  id: string,
+  options?: Omit<UseQueryOptions<PedigreeRecord | null>, 'queryKey' | 'queryFn'>,
+) {
+  return useQuery({
+    queryKey: pedigreeKeys.detail(id),
+    queryFn: async () => {
+      if (!id) return null;
+      const response = await apiClient.get('/pedigrees/{id}', {
+        pathParams: { id } as ApiPathParams<'/pedigrees/{id}', 'get'>,
+      });
+      return (response.data ?? null) as PedigreeRecord | null;
+    },
+    enabled: !!id,
+    ...options,
+  });
+}
+
+export function useGetPedigreeByNumber(
+  pedigreeId: string,
+  options?: Omit<UseQueryOptions<PedigreeRecord | null>, 'queryKey' | 'queryFn'>,
+) {
+  return useQuery({
+    queryKey: pedigreeKeys.byNumber(pedigreeId),
+    queryFn: async () => {
+      if (!pedigreeId) return null;
+      const response = await apiClient.get('/pedigrees/pedigree-id/{pedigreeId}', {
+        pathParams: { pedigreeId } as ApiPathParams<'/pedigrees/pedigree-id/{pedigreeId}', 'get'>,
+      });
+      return (response.data ?? null) as PedigreeRecord | null;
+    },
+    enabled: !!pedigreeId,
+    ...options,
+  });
+}
+
+export function useGetPedigreeFamily(
+  id: string,
+  generations?: number,
+  options?: Omit<UseQueryOptions<unknown>, 'queryKey' | 'queryFn'>,
+) {
+  return useQuery({
+    queryKey: pedigreeKeys.family(id, generations),
+    queryFn: () =>
+      apiClient.get('/pedigrees/{id}/family', {
+        pathParams: { id } as ApiPathParams<'/pedigrees/{id}/family', 'get'>,
+        query: generations
+          ? ({ generations } as unknown as ApiQueryParams<'/pedigrees/{id}/family', 'get'>)
+          : undefined,
+      }),
+    enabled: !!id,
+    ...options,
+  });
+}
+
+export function useGetPedigreeDescendants(
+  id: string,
+  options?: Omit<UseQueryOptions<unknown>, 'queryKey' | 'queryFn'>,
+) {
+  return useQuery({
+    queryKey: pedigreeKeys.descendants(id),
+    queryFn: () =>
+      apiClient.get('/pedigrees/{id}/descendants', {
+        pathParams: { id } as ApiPathParams<'/pedigrees/{id}/descendants', 'get'>,
+      }),
+    enabled: !!id,
+    ...options,
+  });
+}
+
+export function useGetPedigreeFamilyTree(
+  id: string,
+  options?: Omit<UseQueryOptions<unknown>, 'queryKey' | 'queryFn'>,
+) {
+  return useQuery({
+    queryKey: pedigreeKeys.familyTree(id),
+    queryFn: () =>
+      apiClient.get('/pedigrees/{id}/family-tree', {
+        pathParams: { id } as ApiPathParams<'/pedigrees/{id}/family-tree', 'get'>,
+      }),
+    enabled: !!id,
+    ...options,
+  });
+}
+
+export function useCreatePedigree() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: CreatePedigreeRequest) =>
+      apiClient.post('/pedigrees', {
+        body: payload,
+      }),
+    onSuccess: (response) => {
+      const createdId = (response.data as PedigreeRecord | undefined)?.id;
+      void queryClient.invalidateQueries({ queryKey: pedigreeKeys.lists() });
+      if (createdId) {
+        void queryClient.invalidateQueries({ queryKey: pedigreeKeys.detail(createdId) });
+      }
+      notifications.show({
+        title: '血統書データを登録しました',
+        message: '血統書情報が追加されました。',
+        color: 'teal',
+      });
+    },
+    onError: (error: Error) => {
+      notifications.show({
+        title: '血統書データの登録に失敗しました',
+        message: error.message ?? '入力内容をご確認の上、再度お試しください。',
+        color: 'red',
+      });
+    },
+  });
+}
+
+export function useUpdatePedigree(id: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: UpdatePedigreeRequest) =>
+      apiClient.patch('/pedigrees/{id}', {
+        pathParams: { id } as ApiPathParams<'/pedigrees/{id}', 'patch'>,
+        body: payload,
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: pedigreeKeys.lists() });
+      void queryClient.invalidateQueries({ queryKey: pedigreeKeys.detail(id) });
+      notifications.show({
+        title: '血統書データを更新しました',
+        message: '血統書情報を更新しました。',
+        color: 'teal',
+      });
+    },
+    onError: (error: Error) => {
+      notifications.show({
+        title: '血統書データの更新に失敗しました',
+        message: error.message ?? '時間をおいて再度お試しください。',
+        color: 'red',
+      });
+    },
+  });
+}
+
+export function useDeletePedigree() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) =>
+      apiClient.delete('/pedigrees/{id}', {
+        pathParams: { id } as ApiPathParams<'/pedigrees/{id}', 'delete'>,
+      }),
+    onSuccess: (_response, id) => {
+      void queryClient.invalidateQueries({ queryKey: pedigreeKeys.lists() });
+      void queryClient.invalidateQueries({ queryKey: pedigreeKeys.detail(id) });
+      notifications.show({
+        title: '血統書データを削除しました',
+        message: '血統書情報を削除しました。',
+        color: 'teal',
+      });
+    },
+    onError: (error: Error) => {
+      notifications.show({
+        title: '血統書データの削除に失敗しました',
+        message: error.message ?? '時間をおいて再度お試しください。',
+        color: 'red',
+      });
+    },
+  });
+}

--- a/frontend/src/lib/api/hooks/use-tags.ts
+++ b/frontend/src/lib/api/hooks/use-tags.ts
@@ -1,0 +1,154 @@
+/**
+ * タグ管理APIフック
+ */
+
+import { useMutation, useQuery, useQueryClient, type UseQueryOptions } from '@tanstack/react-query';
+import { notifications } from '@mantine/notifications';
+import { apiClient, type ApiPathParams, type ApiRequestBody } from '../client';
+import { createDomainQueryKeys } from './query-key-factory';
+import { catKeys } from './use-cats';
+
+export interface TagSummary {
+  id: string;
+  name: string;
+  color: string;
+  description?: string;
+  usage_count: number;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export type CreateTagRequest = ApiRequestBody<'/tags', 'post'>;
+
+type AssignTagRequest = ApiRequestBody<'/tags/cats/{id}/tags', 'post'>;
+
+type TagListResponse = {
+  success: boolean;
+  data?: TagSummary[];
+  message?: string;
+  error?: string;
+};
+
+const tagKeys = createDomainQueryKeys<string>('tags');
+
+export { tagKeys };
+
+export function useGetTags(
+  options?: Omit<UseQueryOptions<TagListResponse>, 'queryKey' | 'queryFn'>,
+) {
+  return useQuery({
+    queryKey: tagKeys.lists(),
+    queryFn: () => apiClient.get('/tags') as Promise<TagListResponse>,
+    staleTime: 1000 * 60,
+    ...options,
+  });
+}
+
+export function useCreateTag() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: CreateTagRequest) =>
+      apiClient.post('/tags', {
+        body: payload,
+        retryOnUnauthorized: false,
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: tagKeys.lists() });
+      notifications.show({
+        title: 'タグを作成しました',
+        message: '新しいタグが利用可能になりました。',
+        color: 'teal',
+      });
+    },
+    onError: (error: Error) => {
+      notifications.show({
+        title: 'タグの作成に失敗しました',
+        message: error.message ?? '時間をおいて再度お試しください。',
+        color: 'red',
+      });
+    },
+  });
+}
+
+export function useDeleteTag() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) =>
+      apiClient.delete('/tags/{id}', {
+        pathParams: { id } as ApiPathParams<'/tags/{id}', 'delete'>,
+        retryOnUnauthorized: false,
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: tagKeys.lists() });
+      notifications.show({
+        title: 'タグを削除しました',
+        message: 'タグを削除しました。',
+        color: 'teal',
+      });
+    },
+    onError: (error: Error) => {
+      notifications.show({
+        title: 'タグの削除に失敗しました',
+        message: error.message ?? '時間をおいて再度お試しください。',
+        color: 'red',
+      });
+    },
+  });
+}
+
+export function useAssignTagToCat(catId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: AssignTagRequest) =>
+      apiClient.post('/tags/cats/{id}/tags', {
+        pathParams: { id: catId } as ApiPathParams<'/tags/cats/{id}/tags', 'post'>,
+        body: payload,
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: catKeys.detail(catId) });
+      void queryClient.invalidateQueries({ queryKey: catKeys.lists() });
+      notifications.show({
+        title: 'タグを付与しました',
+        message: '猫のタグ情報を更新しました。',
+        color: 'teal',
+      });
+    },
+    onError: (error: Error) => {
+      notifications.show({
+        title: 'タグ付与に失敗しました',
+        message: error.message ?? '時間をおいて再度お試しください。',
+        color: 'red',
+      });
+    },
+  });
+}
+
+export function useUnassignTagFromCat(catId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (tagId: string) =>
+      apiClient.delete('/tags/cats/{id}/tags/{tagId}', {
+        pathParams: { id: catId, tagId } as ApiPathParams<'/tags/cats/{id}/tags/{tagId}', 'delete'>,
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: catKeys.detail(catId) });
+      void queryClient.invalidateQueries({ queryKey: catKeys.lists() });
+      notifications.show({
+        title: 'タグを削除しました',
+        message: '猫からタグを解除しました。',
+        color: 'teal',
+      });
+    },
+    onError: (error: Error) => {
+      notifications.show({
+        title: 'タグ解除に失敗しました',
+        message: error.message ?? '時間をおいて再度お試しください。',
+        color: 'red',
+      });
+    },
+  });
+}

--- a/frontend/src/lib/api/index.ts
+++ b/frontend/src/lib/api/index.ts
@@ -13,6 +13,10 @@ export { QueryClientProvider } from './query-client';
 
 // APIフック
 export * from './hooks/use-cats';
+export * from './hooks/use-tags';
+export * from './hooks/use-breeding';
+export * from './hooks/use-care';
+export * from './hooks/use-pedigrees';
 
 // 型定義（生成後に利用可能）
 export type { paths, components, operations } from './generated/schema';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -252,6 +252,9 @@ importers:
 
   frontend:
     dependencies:
+      '@hookform/resolvers':
+        specifier: ^3.9.0
+        version: 3.10.0(react-hook-form@7.65.0(react@19.1.0))
       '@mantine/core':
         specifier: ^8.2.2
         version: 8.3.2(@mantine/hooks@8.3.2(react@19.1.0))(@types/react@19.1.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -291,6 +294,12 @@ importers:
       react-dom:
         specifier: 19.1.0
         version: 19.1.0(react@19.1.0)
+      react-hook-form:
+        specifier: ^7.53.0
+        version: 7.65.0(react@19.1.0)
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
       zustand:
         specifier: ^5.0.8
         version: 5.0.8(@types/react@19.1.14)(react@19.1.0)
@@ -672,6 +681,11 @@ packages:
 
   '@hapi/topo@6.0.2':
     resolution: {integrity: sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==}
+
+  '@hookform/resolvers@3.10.0':
+    resolution: {integrity: sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==}
+    peerDependencies:
+      react-hook-form: ^7.0.0
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -4925,6 +4939,12 @@ packages:
     peerDependencies:
       react: ^19.1.0
 
+  react-hook-form@7.65.0:
+    resolution: {integrity: sha512-xtOzDz063WcXvGWaHgLNrNzlsdFgtUWcb32E6WFaGTd7kPZG3EeDusjdZfUsPwKCKVXy1ZlntifaHZ4l8pAsmw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -5995,6 +6015,9 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
   zustand@5.0.8:
     resolution: {integrity: sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==}
     engines: {node: '>=12.20.0'}
@@ -6355,6 +6378,10 @@ snapshots:
   '@hapi/topo@6.0.2':
     dependencies:
       '@hapi/hoek': 11.0.7
+
+  '@hookform/resolvers@3.10.0(react-hook-form@7.65.0(react@19.1.0))':
+    dependencies:
+      react-hook-form: 7.65.0(react@19.1.0)
 
   '@humanfs/core@0.19.1': {}
 
@@ -11338,6 +11365,10 @@ snapshots:
       react: 19.1.0
       scheduler: 0.26.0
 
+  react-hook-form@7.65.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+
   react-is@16.13.1: {}
 
   react-is@17.0.2: {}
@@ -12531,6 +12562,8 @@ snapshots:
   yn@3.1.1: {}
 
   yocto-queue@0.1.0: {}
+
+  zod@3.25.76: {}
 
   zustand@5.0.8(@types/react@19.1.14)(react@19.1.0):
     optionalDependencies:


### PR DESCRIPTION
## Summary
- expose breeding NG rule endpoints in Swagger and controllers/services
- add Prisma migration plus dedicated DTOs and e2e coverage
- wire breeding page to new React Query hooks and regenerate API schema

## Testing
- pnpm --dir backend type-check
- pnpm --dir frontend type-check