### PR TITLE
Add tag automation schema artifacts and documentation

### DIFF
--- a/DATABASE_QUICK_REF.md
+++ b/DATABASE_QUICK_REF.md
@@ -25,14 +25,14 @@ pnpm -w run db:deploy    # 本番マイグレーション
 NODE_ENV=production node backend/dist/main.js
 ```
 
-## 🗂️ テーブル構成（11テーブル）
+## 🗂️ テーブル構成（15テーブル）
 
 ### メインテーブル
 
 | テーブル           | 説明         | 主要検索条件                       |
 | ------------------ | ------------ | ---------------------------------- |
 | `users`            | ユーザー管理 | email, role                        |
-| `cats`             | 猫基本情報   | owner_id, breed_id, name           |
+| `cats`             | 猫基本情報   | breed_id, name                     |
 | `pedigrees`        | 血統情報     | pedigree_id, cat_name              |
 | `breeding_records` | 交配記録     | male_id, female_id, breeding_date  |
 | `care_records`     | ケア履歴     | cat_id, care_type, care_date       |
@@ -40,18 +40,23 @@ NODE_ENV=production node backend/dist/main.js
 
 ### マスタテーブル
 
-| テーブル      | 説明 | キーフィールド |
-| ------------- | ---- | -------------- |
-| `breeds`      | 猫種 | code, name     |
-| `coat_colors` | 毛色 | code, name     |
-| `tags`        | タグ | name, color    |
+| テーブル            | 説明             | キーフィールド               |
+| ------------------- | ---------------- | -------------------------- |
+| `breeds`            | 猫種             | code, name                 |
+| `coat_colors`       | 毛色             | code, name                 |
+| `tag_categories`    | タグカテゴリ     | key                        |
+| `tags`              | タグ             | category_id, name          |
+| `tag_automation_rules` | タグ自動化ルール | key                        |
 
 ### 関連テーブル
 
-| テーブル         | 説明         | 関連           |
-| ---------------- | ------------ | -------------- |
-| `login_attempts` | ログイン履歴 | user_id        |
-| `cat_tags`       | 猫タグ関連   | cat_id, tag_id |
+| テーブル                 | 説明                 | 関連                         |
+| ------------------------ | -------------------- | ---------------------------- |
+| `login_attempts`         | ログイン履歴         | user_id                      |
+| `cat_tags`               | 猫タグ関連           | cat_id, tag_id               |
+| `tag_automation_runs`    | タグ自動化実行履歴   | rule_id                      |
+| `tag_assignment_history` | タグ付与/剥奪履歴     | cat_id, tag_id, rule_id      |
+
 
 ## 🔍 よく使用するクエリパターン
 
@@ -179,6 +184,14 @@ WHERE t.name = ?;
 - `MEDIUM` - 中
 - `HIGH` - 高
 - `URGENT` - 緊急
+
+### タグ関連
+
+- **TagAssignmentAction**: `ASSIGNED` / `UNASSIGNED`
+- **TagAssignmentSource**: `MANUAL` / `AUTOMATION` / `SYSTEM`
+- **TagAutomationTriggerType**: `EVENT` / `SCHEDULE` / `MANUAL`
+- **TagAutomationEventType**: `BREEDING_PLANNED` / `BREEDING_CONFIRMED` / `PREGNANCY_CONFIRMED` / `KITTEN_REGISTERED` / `AGE_THRESHOLD` / `CUSTOM`
+- **TagAutomationRunStatus**: `PENDING` / `COMPLETED` / `FAILED`
 
 ## 🔧 メンテナンスコマンド
 

--- a/DATABASE_SCHEMA.md
+++ b/DATABASE_SCHEMA.md
@@ -10,21 +10,26 @@
 - **[詳細スキーマ仕様](./docs/DATABASE_PRODUCTION_SCHEMA.md)** - 本番環境の完全なテーブル・リレーション仕様
 - **[クイックリファレンス](./DATABASE_QUICK_REF.md)** - 開発者向け簡易リファレンス
 
-## 🗂️ 主要テーブル一覧（11テーブル）
+## 🗂️ 主要テーブル一覧（15テーブル）
 
-| No. | テーブル名   | 物理名             | 概要                 | 主要フィールド                                                |
-| --- | ------------ | ------------------ | -------------------- | ------------------------------------------------------------- |
-| 1   | ユーザー     | `users`            | システム利用者管理   | email, name, role, clerk_id                                   |
-| 2   | ログイン試行 | `login_attempts`   | セキュリティ監査ログ | user_id, email, success, ip_address                           |
-| 3   | 猫種マスタ   | `breeds`           | 猫の品種定義         | code, name, description                                       |
-| 4   | 毛色マスタ   | `coat_colors`      | 毛色分類定義         | code, name, description                                       |
-| 5   | 猫基本情報   | `cats`             | 猫の個体情報         | name, birth_date, gender, breed_id, owner_id                  |
-| 6   | 交配記録     | `breeding_records` | 交配・繁殖履歴       | male_id, female_id, breeding_date, status                     |
-| 7   | ケア記録     | `care_records`     | 医療・ケア履歴       | cat_id, care_type, care_date, description                     |
-| 8   | スケジュール | `schedules`        | 予定・タスク管理     | title, schedule_date, type, status, cat_id                    |
-| 9   | タグマスタ   | `tags`             | 分類用タグ定義       | name, color, description                                      |
-| 10  | 血統情報     | `pedigrees`        | 血統書・家系図       | pedigree_id, cat_name, father_pedigree_id, mother_pedigree_id |
-| 11  | 猫タグ関連   | `cat_tags`         | 猫とタグの多対多     | cat_id, tag_id                                                |
+| No. | テーブル名           | 物理名                   | 概要                       | 主要フィールド |
+| --- | -------------------- | ------------------------ | -------------------------- | -------------- |
+| 1   | ユーザー             | `users`                  | システム利用者管理         | email, name, role, clerk_id |
+| 2   | ログイン試行         | `login_attempts`         | セキュリティ監査ログ       | user_id, email, success, ip_address |
+| 3   | 猫種マスタ           | `breeds`                 | 猫の品種定義               | code, name, description |
+| 4   | 毛色マスタ           | `coat_colors`            | 毛色分類定義               | code, name, description |
+| 5   | 猫基本情報           | `cats`                   | 猫の個体情報               | name, birth_date, gender, breed_id |
+| 6   | 交配記録             | `breeding_records`       | 交配・繁殖履歴             | male_id, female_id, breeding_date, status |
+| 7   | ケア記録             | `care_records`           | 医療・ケア履歴             | cat_id, care_type, care_date, description |
+| 8   | スケジュール         | `schedules`              | 予定・タスク管理           | title, schedule_date, type, status, cat_id |
+| 9   | タグカテゴリ         | `tag_categories`         | タグの分類カテゴリ定義     | key, name, scopes, display_order |
+| 10  | タグマスタ           | `tags`                   | カテゴリ配下のタグ定義     | category_id, name, allows_manual, allows_automation |
+| 11  | タグ自動化ルール     | `tag_automation_rules`   | 自動付与ルール定義         | key, trigger_type, event_type, priority |
+| 12  | タグ自動化実行       | `tag_automation_runs`    | 自動付与実行履歴           | rule_id, status, started_at |
+| 13  | タグ付与履歴         | `tag_assignment_history` | タグ付与/剥奪の履歴管理     | cat_id, tag_id, action, source |
+| 14  | 猫タグ関連           | `cat_tags`               | 猫とタグの多対多           | cat_id, tag_id |
+| 15  | 血統情報             | `pedigrees`              | 血統書・家系図             | pedigree_id, cat_name, father_pedigree_id, mother_pedigree_id |
+
 
 ## 🔗 主要リレーション設計
 
@@ -93,6 +98,14 @@ pedigrees (1) ───────→ (∞) pedigrees           [血統関係�
 - **ScheduleStatus**: `PENDING`, `IN_PROGRESS`, `COMPLETED`, `CANCELLED`
 - **Priority**: `LOW`, `MEDIUM`, `HIGH`, `URGENT`
 
+### タグ関連
+
+- **TagAssignmentAction**: `ASSIGNED`, `UNASSIGNED`
+- **TagAssignmentSource**: `MANUAL`, `AUTOMATION`, `SYSTEM`
+- **TagAutomationTriggerType**: `EVENT`, `SCHEDULE`, `MANUAL`
+- **TagAutomationEventType**: `BREEDING_PLANNED`, `BREEDING_CONFIRMED`, `PREGNANCY_CONFIRMED`, `KITTEN_REGISTERED`, `AGE_THRESHOLD`, `CUSTOM`
+- **TagAutomationRunStatus**: `PENDING`, `COMPLETED`, `FAILED`
+
 ## 🔑 重要な制約とインデックス
 
 ### 一意制約（UNIQUE）
@@ -101,12 +114,14 @@ pedigrees (1) ───────→ (∞) pedigrees           [血統関係�
 - `breeds`: `code`, `name`
 - `coat_colors`: `code`, `name`
 - `cats`: `registration_id`, `microchip_id`
-- `tags`: `name`
+- `tag_categories`: `key`
+- `tags`: (`category_id`, `name`)
+- `tag_automation_rules`: `key`
 - `pedigrees`: `pedigree_id`
 
 ### 外部キー制約の削除動作
 
-- **CASCADE削除**: `login_attempts`, `care_records`, `cat_tags`
+- **CASCADE削除**: `login_attempts`, `care_records`, `cat_tags`, `tag_assignment_history`
 - **SET NULL**: `cats` (父母関係), `pedigrees` (血統関係), `schedules`
 - **RESTRICT**: `users`関連の重要なレコード
 

--- a/backend/prisma/migrations/20251015090000_add_tag_category_automation/migration.sql
+++ b/backend/prisma/migrations/20251015090000_add_tag_category_automation/migration.sql
@@ -1,0 +1,171 @@
+-- CreateEnum
+CREATE TYPE "TagAssignmentAction" AS ENUM ('ASSIGNED', 'UNASSIGNED');
+
+-- CreateEnum
+CREATE TYPE "TagAssignmentSource" AS ENUM ('MANUAL', 'AUTOMATION', 'SYSTEM');
+
+-- CreateEnum
+CREATE TYPE "TagAutomationTriggerType" AS ENUM ('EVENT', 'SCHEDULE', 'MANUAL');
+
+-- CreateEnum
+CREATE TYPE "TagAutomationEventType" AS ENUM (
+    'BREEDING_PLANNED',
+    'BREEDING_CONFIRMED',
+    'PREGNANCY_CONFIRMED',
+    'KITTEN_REGISTERED',
+    'AGE_THRESHOLD',
+    'CUSTOM'
+);
+
+-- CreateEnum
+CREATE TYPE "TagAutomationRunStatus" AS ENUM ('PENDING', 'COMPLETED', 'FAILED');
+
+-- CreateTable
+CREATE TABLE "tag_categories" (
+    "id" TEXT NOT NULL,
+    "key" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "color" TEXT DEFAULT '#3B82F6',
+    "display_order" INTEGER NOT NULL DEFAULT 0,
+    "scopes" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    "is_active" BOOLEAN NOT NULL DEFAULT true,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "tag_categories_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "tag_automation_rules" (
+    "id" TEXT NOT NULL,
+    "key" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "trigger_type" "TagAutomationTriggerType" NOT NULL,
+    "event_type" "TagAutomationEventType" NOT NULL,
+    "scope" TEXT,
+    "is_active" BOOLEAN NOT NULL DEFAULT true,
+    "priority" INTEGER NOT NULL DEFAULT 0,
+    "config" JSONB,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "tag_automation_rules_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "tag_automation_runs" (
+    "id" TEXT NOT NULL,
+    "rule_id" TEXT NOT NULL,
+    "event_payload" JSONB,
+    "status" "TagAutomationRunStatus" NOT NULL DEFAULT 'PENDING',
+    "started_at" TIMESTAMP(3),
+    "completed_at" TIMESTAMP(3),
+    "error_message" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "tag_automation_runs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "tag_assignment_history" (
+    "id" TEXT NOT NULL,
+    "cat_id" TEXT NOT NULL,
+    "tag_id" TEXT NOT NULL,
+    "rule_id" TEXT,
+    "automation_run_id" TEXT,
+    "action" "TagAssignmentAction" NOT NULL DEFAULT 'ASSIGNED',
+    "source" "TagAssignmentSource" NOT NULL DEFAULT 'MANUAL',
+    "reason" TEXT,
+    "metadata" JSONB,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "tag_assignment_history_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "tag_categories_key_key" ON "tag_categories"("key");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "tag_automation_rules_key_key" ON "tag_automation_rules"("key");
+
+-- AlterTable
+ALTER TABLE "tags"
+    ADD COLUMN "category_id" TEXT,
+    ADD COLUMN "display_order" INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN "allows_manual" BOOLEAN NOT NULL DEFAULT true,
+    ADD COLUMN "allows_automation" BOOLEAN NOT NULL DEFAULT true,
+    ADD COLUMN "metadata" JSONB,
+    ADD COLUMN "is_active" BOOLEAN NOT NULL DEFAULT true;
+
+-- Insert default category for legacy tags
+INSERT INTO "tag_categories" (
+    "id", "key", "name", "description", "color", "display_order", "scopes", "is_active"
+) VALUES (
+    'tag-cat-legacy-default',
+    'legacy_default',
+    '既存タグ',
+    'カテゴリ導入前に存在していたタグの自動分類用カテゴリ',
+    '#3B82F6',
+    0,
+    ARRAY['cats'],
+    true
+)
+ON CONFLICT ("key") DO NOTHING;
+
+-- Assign all existing tags to the default category
+UPDATE "tags"
+SET "category_id" = 'tag-cat-legacy-default'
+WHERE "category_id" IS NULL;
+
+-- Populate display order for legacy tags based on name ordering
+WITH ordered_tags AS (
+    SELECT "id", ROW_NUMBER() OVER (ORDER BY "name") - 1 AS rn
+    FROM "tags"
+)
+UPDATE "tags" AS t
+SET "display_order" = o.rn
+FROM ordered_tags AS o
+WHERE t."id" = o."id";
+
+-- After data backfill enforce NOT NULL and constraints
+ALTER TABLE "tags"
+    ALTER COLUMN "category_id" SET NOT NULL;
+
+-- Drop legacy unique constraint and add scoped unique constraint
+DROP INDEX IF EXISTS "tags_name_key";
+CREATE UNIQUE INDEX "tags_category_id_name_key" ON "tags"("category_id", "name");
+
+-- AddForeignKey
+ALTER TABLE "tags"
+    ADD CONSTRAINT "tags_category_id_fkey" FOREIGN KEY ("category_id") REFERENCES "tag_categories"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "tag_automation_runs"
+    ADD CONSTRAINT "tag_automation_runs_rule_id_fkey" FOREIGN KEY ("rule_id") REFERENCES "tag_automation_rules"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "tag_assignment_history"
+    ADD CONSTRAINT "tag_assignment_history_cat_id_fkey" FOREIGN KEY ("cat_id") REFERENCES "cats"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "tag_assignment_history"
+    ADD CONSTRAINT "tag_assignment_history_tag_id_fkey" FOREIGN KEY ("tag_id") REFERENCES "tags"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "tag_assignment_history"
+    ADD CONSTRAINT "tag_assignment_history_rule_id_fkey" FOREIGN KEY ("rule_id") REFERENCES "tag_automation_rules"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "tag_assignment_history"
+    ADD CONSTRAINT "tag_assignment_history_automation_run_id_fkey" FOREIGN KEY ("automation_run_id") REFERENCES "tag_automation_runs"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddIndex
+CREATE INDEX "tag_automation_runs_rule_id_idx" ON "tag_automation_runs"("rule_id");
+CREATE INDEX "tag_assignment_history_cat_id_idx" ON "tag_assignment_history"("cat_id");
+CREATE INDEX "tag_assignment_history_tag_id_idx" ON "tag_assignment_history"("tag_id");
+CREATE INDEX "tag_assignment_history_rule_id_idx" ON "tag_assignment_history"("rule_id");
+CREATE INDEX "tag_assignment_history_automation_run_id_idx" ON "tag_assignment_history"("automation_run_id");
+

--- a/backend/prisma/schema_prisma.txt
+++ b/backend/prisma/schema_prisma.txt
@@ -421,25 +421,91 @@ model TagCategory {
 }
 
 model Tag {
-  id                String  @id @default(uuid())
-  categoryId        String  @map("category_id")
-  name              String
-  color             String  @default("#3B82F6")
-  description       String?
-  allowsManual      Boolean @default(true) @map("allows_manual")
-  allowsAutomation  Boolean @default(true) @map("allows_automation")
-  metadata          Json?
-  isActive          Boolean @default(true) @map("is_active")
+  id               String  @id @default(uuid())
+  categoryId       String  @map("category_id")
+  name             String
+  color            String  @default("#3B82F6")
+  description      String?
+  displayOrder     Int     @default(0) @map("display_order")
+  allowsManual     Boolean @default(true) @map("allows_manual")
+  allowsAutomation Boolean @default(true) @map("allows_automation")
+  metadata         Json?
+  isActive         Boolean @default(true) @map("is_active")
 
-  category TagCategory @relation(fields: [categoryId], references: [id], onDelete: Cascade)
+  category TagCategory            @relation(fields: [categoryId], references: [id], onDelete: Cascade)
   cats     CatTag[]
-  history TagAssignmentHistory[]
+  history  TagAssignmentHistory[]
 
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 
   @@unique([categoryId, name])
   @@map("tags")
+}
+
+model TagAutomationRule {
+  id          String                   @id @default(uuid())
+  key         String                   @unique
+  name        String
+  description String?
+  triggerType TagAutomationTriggerType @map("trigger_type")
+  eventType   TagAutomationEventType   @map("event_type")
+  scope       String?                  @map("scope")
+  isActive    Boolean                  @default(true) @map("is_active")
+  priority    Int                      @default(0)
+  config      Json?                    @map("config")
+
+  runs    TagAutomationRun[]
+  history TagAssignmentHistory[]
+
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  @@map("tag_automation_rules")
+}
+
+model TagAutomationRun {
+  id           String                 @id @default(uuid())
+  ruleId       String                 @map("rule_id")
+  eventPayload Json?                  @map("event_payload")
+  status       TagAutomationRunStatus @default(PENDING) @map("status")
+  startedAt    DateTime?              @map("started_at")
+  completedAt  DateTime?              @map("completed_at")
+  errorMessage String?                @map("error_message")
+
+  rule    TagAutomationRule      @relation(fields: [ruleId], references: [id], onDelete: Cascade)
+  history TagAssignmentHistory[]
+
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  @@index([ruleId])
+  @@map("tag_automation_runs")
+}
+
+model TagAssignmentHistory {
+  id              String              @id @default(uuid())
+  catId           String              @map("cat_id")
+  tagId           String              @map("tag_id")
+  ruleId          String?             @map("rule_id")
+  automationRunId String?             @map("automation_run_id")
+  action          TagAssignmentAction @default(ASSIGNED)
+  source          TagAssignmentSource @default(MANUAL)
+  reason          String?
+  metadata        Json?
+
+  cat           Cat                @relation(fields: [catId], references: [id], onDelete: Cascade)
+  tag           Tag                @relation(fields: [tagId], references: [id], onDelete: Cascade)
+  rule          TagAutomationRule? @relation(fields: [ruleId], references: [id])
+  automationRun TagAutomationRun?  @relation(fields: [automationRunId], references: [id])
+
+  createdAt DateTime @default(now()) @map("created_at")
+
+  @@index([catId])
+  @@index([tagId])
+  @@index([ruleId])
+  @@index([automationRunId])
+  @@map("tag_assignment_history")
 }
 
 model Pedigree {

--- a/backend/src/tags/tag-automation.service.ts
+++ b/backend/src/tags/tag-automation.service.ts
@@ -317,10 +317,10 @@ export class TagAutomationService {
 
     operations.push(historyCreate);
 
-  const results = await this.prisma.$transaction(operations);
-  const history = results[results.length - 1] as Awaited<typeof historyCreate>;
+    const results = await this.prisma.$transaction(operations);
+    const history = results[results.length - 1] as Awaited<typeof historyCreate>;
 
-  return { success: true, data: history };
+    return { success: true, data: history };
   }
 
   async getHistoryForCat(catId: string, options: { take?: number; tagId?: string } = {}) {


### PR DESCRIPTION
## Summary
- add a Prisma migration introducing tag categories, automation tables, and history indices
- update bootstrap SQL scripts and Prisma schema snapshots to match the new tag data model
- refresh database documentation to cover tag categories, automation, and updated table counts
- correct tag automation service assignment transaction indentation for readability

## Testing
- pnpm --filter backend test -- tag-automation *(fails: Prisma engines download blocked in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68ed20d5a5e88330944c6e5228797335