### PR TITLE
fix: 検証レポートの重大不具合を修正（起動不能・タグ自動運用・猫削除・配種スケジュール永続化ほか）

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -4423,6 +4423,53 @@
         ]
       }
     },
+    "/api/v1/care/schedules/{id}/status": {
+      "patch": {
+        "operationId": "CareController_updateScheduleStatus",
+        "summary": "ケアスケジュールのステータス変更（有効/無効）",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "スケジュールID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateCareStatusDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CareScheduleResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Care"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
     "/api/v1/care/medical-records": {
       "get": {
         "operationId": "CareController_findMedicalRecords",
@@ -7708,6 +7755,11 @@
             "type": "string",
             "description": "メモ",
             "example": "初回の交配。"
+          },
+          "force": {
+            "type": "boolean",
+            "description": "NGペアルール違反時でも強行登録する場合に true",
+            "example": false
           }
         },
         "required": [
@@ -8117,6 +8169,11 @@
           "notes": {
             "type": "string",
             "description": "メモ"
+          },
+          "force": {
+            "type": "boolean",
+            "description": "NGペアルール違反時でも強行登録する場合に true",
+            "example": false
           }
         },
         "required": [
@@ -8160,6 +8217,11 @@
           "notes": {
             "type": "string",
             "description": "メモ"
+          },
+          "force": {
+            "type": "boolean",
+            "description": "NGペアルール違反時でも強行登録する場合に true",
+            "example": false
           }
         }
       },
@@ -8786,6 +8848,24 @@
         "required": [
           "success",
           "data"
+        ]
+      },
+      "UpdateCareStatusDto": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "PENDING",
+              "IN_PROGRESS",
+              "COMPLETED",
+              "CANCELLED"
+            ],
+            "example": "PENDING"
+          }
+        },
+        "required": [
+          "status"
         ]
       },
       "MedicalRecordVisitTypeDto": {

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1138,6 +1138,26 @@
         ]
       }
     },
+    "/api/v1/cats/genders": {
+      "get": {
+        "operationId": "CatsController_getGenders",
+        "summary": "性別マスタデータを取得",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "性別マスタデータを返却"
+          }
+        },
+        "tags": [
+          "Cats"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
     "/api/v1/cats/{id}": {
       "get": {
         "operationId": "CatsController_findOne",
@@ -1333,26 +1353,6 @@
           },
           "404": {
             "description": "猫データが見つかりません"
-          }
-        },
-        "tags": [
-          "Cats"
-        ],
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      }
-    },
-    "/api/v1/cats/genders": {
-      "get": {
-        "operationId": "CatsController_getGenders",
-        "summary": "性別マスタデータを取得",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "性別マスタデータを返却"
           }
         },
         "tags": [
@@ -4638,6 +4638,11 @@
         },
         "tags": [
           "Care"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
         ]
       },
       "patch": {

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -5453,7 +5453,7 @@
     "/api/v1/tags/automation/rules/{id}/execute": {
       "post": {
         "operationId": "TagAutomationController_executeRule",
-        "summary": "ルールを手動実行（テスト用）",
+        "summary": "ルールを手動実行（実データの対象猫に即時適用）",
         "parameters": [
           {
             "name": "id",
@@ -5467,7 +5467,7 @@
         ],
         "responses": {
           "200": {
-            "description": "ルール実行成功"
+            "description": "ルール実行結果"
           }
         },
         "tags": [

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -224,6 +224,641 @@
         ]
       }
     },
+    "/api/v1/users": {
+      "get": {
+        "operationId": "UsersController_listUsers",
+        "summary": "ユーザー一覧取得",
+        "description": "SUPER_ADMINは全ユーザー、TENANT_ADMINは自テナントのユーザーを取得します。",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "required": false,
+            "in": "query",
+            "description": "テナント ID でフィルタ（SUPER_ADMIN のみ有効）",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ユーザー一覧を返却"
+          },
+          "401": {
+            "description": "認証が必要です"
+          },
+          "403": {
+            "description": "権限がありません"
+          }
+        },
+        "tags": [
+          "users"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/users/me": {
+      "get": {
+        "operationId": "UsersController_getMe",
+        "summary": "自身のプロフィール取得",
+        "description": "JWTで認証されたユーザー自身のプロフィール情報を取得します。",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "プロフィール情報を返却"
+          },
+          "401": {
+            "description": "認証が必要です"
+          },
+          "404": {
+            "description": "ユーザーが見つかりません"
+          }
+        },
+        "tags": [
+          "users"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      },
+      "patch": {
+        "operationId": "UsersController_updateMe",
+        "summary": "自身のプロフィール更新",
+        "description": "JWTで認証されたユーザー自身のプロフィール情報を更新します。各フィールドはオプショナルです。",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateProfileDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "プロフィールが更新されました"
+          },
+          "400": {
+            "description": "更新するフィールドがありません"
+          },
+          "401": {
+            "description": "認証が必要です"
+          },
+          "409": {
+            "description": "メールアドレスが既に使用されています"
+          }
+        },
+        "tags": [
+          "users"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/users/invite": {
+      "post": {
+        "operationId": "UsersController_inviteUser",
+        "summary": "ユーザー招待",
+        "description": "SUPER_ADMINは任意のテナント、TENANT_ADMINは自テナントにユーザーを招待します。",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InviteUserDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "招待が作成されました"
+          },
+          "401": {
+            "description": "認証が必要です"
+          },
+          "403": {
+            "description": "権限がありません"
+          },
+          "404": {
+            "description": "テナントが見つかりません"
+          },
+          "409": {
+            "description": "メールアドレスが既に使用されています"
+          }
+        },
+        "tags": [
+          "users"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/users/{id}/role": {
+      "patch": {
+        "operationId": "UsersController_updateUserRole",
+        "summary": "ユーザーロール変更",
+        "description": "SUPER_ADMINは任意のユーザー、TENANT_ADMINは自テナントのADMIN/USERのロールを変更します。",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "対象ユーザー ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateUserRoleDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "ロールが更新されました"
+          },
+          "401": {
+            "description": "認証が必要です"
+          },
+          "403": {
+            "description": "権限がありません"
+          },
+          "404": {
+            "description": "ユーザーが見つかりません"
+          }
+        },
+        "tags": [
+          "users"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/users/{id}": {
+      "delete": {
+        "operationId": "UsersController_deleteUser",
+        "summary": "ユーザー削除",
+        "description": "SUPER_ADMINは任意のユーザー（自分と他のSUPER_ADMINを除く）、TENANT_ADMINは自テナントのADMIN/USERを削除します。",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "対象ユーザー ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ユーザーが削除されました"
+          },
+          "401": {
+            "description": "認証が必要です"
+          },
+          "403": {
+            "description": "権限がありません"
+          },
+          "404": {
+            "description": "ユーザーが見つかりません"
+          }
+        },
+        "tags": [
+          "users"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/tenants": {
+      "get": {
+        "operationId": "TenantsController_listTenants",
+        "summary": "テナント一覧取得",
+        "description": "SuperAdminのみが実行可能。全テナントの一覧を取得します。",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "テナント一覧を返却"
+          },
+          "401": {
+            "description": "認証が必要です"
+          },
+          "403": {
+            "description": "権限がありません"
+          }
+        },
+        "tags": [
+          "tenants"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      },
+      "post": {
+        "operationId": "TenantsController_createTenant",
+        "summary": "テナント作成",
+        "description": "SuperAdminのみが実行可能。新しいテナントを作成します。",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateTenantDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "テナントが作成されました"
+          },
+          "400": {
+            "description": "不正なリクエスト"
+          },
+          "403": {
+            "description": "権限がありません"
+          },
+          "409": {
+            "description": "スラッグが既に使用されています"
+          }
+        },
+        "tags": [
+          "tenants"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/tenants/{id}": {
+      "get": {
+        "operationId": "TenantsController_getTenantById",
+        "summary": "テナント詳細取得",
+        "description": "SuperAdminまたはテナント管理者（自テナントのみ）が実行可能。指定IDのテナント詳細を取得します。",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "テナント詳細を返却"
+          },
+          "401": {
+            "description": "認証が必要です"
+          },
+          "403": {
+            "description": "権限がありません"
+          },
+          "404": {
+            "description": "テナントが見つかりません"
+          }
+        },
+        "tags": [
+          "tenants"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      },
+      "patch": {
+        "operationId": "TenantsController_updateTenant",
+        "summary": "テナント更新",
+        "description": "SuperAdminのみが実行可能。指定IDのテナントを更新します。",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateTenantDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "テナントが更新されました"
+          },
+          "401": {
+            "description": "認証が必要です"
+          },
+          "403": {
+            "description": "権限がありません"
+          },
+          "404": {
+            "description": "テナントが見つかりません"
+          },
+          "409": {
+            "description": "スラッグが既に使用されています"
+          }
+        },
+        "tags": [
+          "tenants"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "TenantsController_deleteTenant",
+        "summary": "テナント削除",
+        "description": "SuperAdminのみが実行可能。指定IDのテナントを削除します。所属ユーザーがいる場合は削除できません。",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "テナントが削除されました"
+          },
+          "401": {
+            "description": "認証が必要です"
+          },
+          "403": {
+            "description": "権限がありません"
+          },
+          "404": {
+            "description": "テナントが見つかりません"
+          },
+          "409": {
+            "description": "所属ユーザーが存在するため削除できません"
+          }
+        },
+        "tags": [
+          "tenants"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/tenants/invite-admin": {
+      "post": {
+        "operationId": "TenantsController_inviteTenantAdmin",
+        "summary": "テナント管理者を招待",
+        "description": "SuperAdminのみが実行可能。新しいテナントを作成し、管理者を招待します。",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InviteTenantAdminDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "招待が正常に作成されました"
+          },
+          "400": {
+            "description": "不正なリクエスト"
+          },
+          "403": {
+            "description": "権限がありません"
+          },
+          "409": {
+            "description": "メールアドレスまたはスラッグが既に使用されています"
+          }
+        },
+        "tags": [
+          "tenants"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/tenants/{tenantId}/users/invite": {
+      "post": {
+        "operationId": "TenantsController_inviteUser",
+        "summary": "ユーザーを招待",
+        "description": "テナント管理者が自分のテナントにユーザーを招待します。",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InviteUserDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "招待が正常に作成されました"
+          },
+          "400": {
+            "description": "不正なリクエスト"
+          },
+          "403": {
+            "description": "権限がありません"
+          },
+          "404": {
+            "description": "テナントが見つかりません"
+          },
+          "409": {
+            "description": "メールアドレスが既に使用されています"
+          }
+        },
+        "tags": [
+          "tenants"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/tenants/complete-invitation": {
+      "post": {
+        "operationId": "TenantsController_completeInvitation",
+        "summary": "招待完了",
+        "description": "招待トークンを使用してユーザー登録を完了します。認証不要。",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CompleteInvitationDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "ユーザー登録が完了しました"
+          },
+          "400": {
+            "description": "不正なリクエストまたは無効なトークン"
+          },
+          "409": {
+            "description": "メールアドレスが既に使用されています"
+          }
+        },
+        "tags": [
+          "tenants"
+        ]
+      }
+    },
+    "/api/v1/tenant-settings/tag-color-defaults": {
+      "get": {
+        "operationId": "TenantSettingsController_getTagColorDefaults",
+        "summary": "タグカラーデフォルト設定を取得",
+        "description": "テナントのタグカラーデフォルト設定を取得します。設定が存在しない場合はフロントエンドのデフォルト値を返します。",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "タグカラーデフォルト設定を返却",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagColorDefaultsDto"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証が必要です"
+          },
+          "404": {
+            "description": "テナントが見つかりません"
+          }
+        },
+        "tags": [
+          "tenant-settings"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      },
+      "put": {
+        "operationId": "TenantSettingsController_updateTagColorDefaults",
+        "summary": "タグカラーデフォルト設定を更新",
+        "description": "テナントのタグカラーデフォルト設定を更新します。部分更新をサポートしています。",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateTagColorDefaultsDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "タグカラーデフォルト設定が更新されました",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagColorDefaultsDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "不正なリクエスト"
+          },
+          "401": {
+            "description": "認証が必要です"
+          },
+          "403": {
+            "description": "権限がありません"
+          },
+          "404": {
+            "description": "テナントが見つかりません"
+          }
+        },
+        "tags": [
+          "tenant-settings"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
     "/api/v1/cats": {
       "post": {
         "operationId": "CatsController_create",
@@ -329,6 +964,15 @@
             }
           },
           {
+            "name": "isInHouse",
+            "required": false,
+            "in": "query",
+            "description": "在舎中フィルター",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
             "name": "ageMin",
             "required": false,
             "in": "query",
@@ -399,6 +1043,89 @@
         "responses": {
           "200": {
             "description": "統計情報"
+          }
+        },
+        "tags": [
+          "Cats"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/cats/kittens": {
+      "get": {
+        "operationId": "CatsController_findKittens",
+        "summary": "子猫一覧を取得（生後6ヶ月未満、母猫ごとにグループ化）",
+        "parameters": [
+          {
+            "name": "motherId",
+            "required": false,
+            "in": "query",
+            "description": "母猫ID（指定時はその母猫の子猫のみ取得）",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "description": "ページ番号",
+            "schema": {
+              "default": 1,
+              "example": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "description": "1ページあたりの件数",
+            "schema": {
+              "default": 50,
+              "example": 50,
+              "type": "number"
+            }
+          },
+          {
+            "name": "search",
+            "required": false,
+            "in": "query",
+            "description": "検索キーワード（子猫名）",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortBy",
+            "required": false,
+            "in": "query",
+            "description": "ソート項目",
+            "schema": {
+              "default": "birthDate",
+              "example": "birthDate",
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortOrder",
+            "required": false,
+            "in": "query",
+            "description": "ソート順",
+            "schema": {
+              "default": "desc",
+              "example": "desc",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "子猫データの一覧（母猫ごとにグループ化）"
           }
         },
         "tags": [
@@ -585,6 +1312,39 @@
         ]
       }
     },
+    "/api/v1/cats/{id}/family": {
+      "get": {
+        "operationId": "CatsController_getCatFamily",
+        "summary": "猫の家族情報を取得（血統タブ用）",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "猫データのID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "家族情報（親・兄弟姉妹・子猫）"
+          },
+          "404": {
+            "description": "猫データが見つかりません"
+          }
+        },
+        "tags": [
+          "Cats"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
     "/api/v1/cats/genders": {
       "get": {
         "operationId": "CatsController_getGenders",
@@ -593,6 +1353,277 @@
         "responses": {
           "200": {
             "description": "性別マスタデータを返却"
+          }
+        },
+        "tags": [
+          "Cats"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/cats/{id}/weight-records": {
+      "get": {
+        "operationId": "CatsController_getWeightRecords",
+        "summary": "猫の体重記録一覧を取得",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "猫データのID",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "description": "ページ番号",
+            "schema": {
+              "default": 1,
+              "example": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "description": "1ページあたりの件数",
+            "schema": {
+              "default": 50,
+              "example": 50,
+              "type": "number"
+            }
+          },
+          {
+            "name": "startDate",
+            "required": false,
+            "in": "query",
+            "description": "開始日",
+            "schema": {
+              "example": "2024-01-01",
+              "type": "string"
+            }
+          },
+          {
+            "name": "endDate",
+            "required": false,
+            "in": "query",
+            "description": "終了日",
+            "schema": {
+              "example": "2024-12-31",
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortOrder",
+            "required": false,
+            "in": "query",
+            "description": "ソート順",
+            "schema": {
+              "default": "desc",
+              "example": "desc",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "体重記録一覧"
+          },
+          "404": {
+            "description": "猫データが見つかりません"
+          }
+        },
+        "tags": [
+          "Cats"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      },
+      "post": {
+        "operationId": "CatsController_createWeightRecord",
+        "summary": "猫の体重記録を追加",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "猫データのID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateWeightRecordDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "体重記録が正常に作成されました"
+          },
+          "400": {
+            "description": "無効なデータです"
+          },
+          "404": {
+            "description": "猫データが見つかりません"
+          }
+        },
+        "tags": [
+          "Cats"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/cats/weight-records/{recordId}": {
+      "get": {
+        "operationId": "CatsController_getWeightRecord",
+        "summary": "体重記録を取得",
+        "parameters": [
+          {
+            "name": "recordId",
+            "required": true,
+            "in": "path",
+            "description": "体重記録のID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "体重記録"
+          },
+          "404": {
+            "description": "体重記録が見つかりません"
+          }
+        },
+        "tags": [
+          "Cats"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      },
+      "patch": {
+        "operationId": "CatsController_updateWeightRecord",
+        "summary": "体重記録を更新",
+        "parameters": [
+          {
+            "name": "recordId",
+            "required": true,
+            "in": "path",
+            "description": "体重記録のID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateWeightRecordDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "体重記録が正常に更新されました"
+          },
+          "400": {
+            "description": "無効なデータです"
+          },
+          "404": {
+            "description": "体重記録が見つかりません"
+          }
+        },
+        "tags": [
+          "Cats"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "CatsController_deleteWeightRecord",
+        "summary": "体重記録を削除",
+        "parameters": [
+          {
+            "name": "recordId",
+            "required": true,
+            "in": "path",
+            "description": "体重記録のID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "体重記録が正常に削除されました"
+          },
+          "404": {
+            "description": "体重記録が見つかりません"
+          }
+        },
+        "tags": [
+          "Cats"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/cats/weight-records/bulk": {
+      "post": {
+        "operationId": "CatsController_createBulkWeightRecords",
+        "summary": "複数の猫の体重を一括登録",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateBulkWeightRecordsDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "体重記録が正常に一括作成されました"
+          },
+          "400": {
+            "description": "無効なデータです"
           }
         },
         "tags": [
@@ -633,6 +1664,11 @@
         },
         "tags": [
           "Pedigrees"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
         ]
       },
       "get": {
@@ -745,6 +1781,152 @@
         },
         "tags": [
           "Pedigrees"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/pedigrees/next-id": {
+      "get": {
+        "operationId": "PedigreeController_getNextId",
+        "summary": "次の血統書番号を取得",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "次の血統書番号"
+          }
+        },
+        "tags": [
+          "Pedigrees"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/pedigrees/print-settings": {
+      "get": {
+        "operationId": "PedigreeController_getPrintSettings",
+        "summary": "印刷設定を取得",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "現在の印刷設定"
+          }
+        },
+        "tags": [
+          "Pedigrees"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      },
+      "patch": {
+        "operationId": "PedigreeController_updatePrintSettings",
+        "summary": "印刷設定を更新",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "更新後の印刷設定"
+          },
+          "400": {
+            "description": "無効な設定データです"
+          }
+        },
+        "tags": [
+          "Pedigrees"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/pedigrees/print-settings/reset": {
+      "post": {
+        "operationId": "PedigreeController_resetPrintSettings",
+        "summary": "印刷設定をデフォルトにリセット",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "リセット後の印刷設定"
+          }
+        },
+        "tags": [
+          "Pedigrees"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/pedigrees/pedigree-id/{pedigreeId}/pdf": {
+      "get": {
+        "operationId": "PedigreeController_generatePdf",
+        "summary": "血統書PDFを生成してダウンロード",
+        "parameters": [
+          {
+            "name": "pedigreeId",
+            "required": true,
+            "in": "path",
+            "description": "血統書番号",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "format",
+            "required": false,
+            "in": "query",
+            "description": "出力形式 (pdf|base64)",
+            "schema": {
+              "example": "pdf",
+              "type": "string"
+            }
+          },
+          {
+            "name": "debug",
+            "required": false,
+            "in": "query",
+            "description": "デバッグモード（背景画像表示）",
+            "schema": {
+              "example": "false",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "PDF生成成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "血統書データが見つかりません"
+          }
+        },
+        "tags": [
+          "Pedigrees"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
         ]
       }
     },
@@ -773,6 +1955,11 @@
         },
         "tags": [
           "Pedigrees"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
         ]
       }
     },
@@ -801,6 +1988,11 @@
         },
         "tags": [
           "Pedigrees"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
         ]
       },
       "patch": {
@@ -843,6 +2035,11 @@
         },
         "tags": [
           "Pedigrees"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
         ]
       },
       "delete": {
@@ -872,6 +2069,11 @@
         },
         "tags": [
           "Pedigrees"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
         ]
       }
     },
@@ -900,6 +2102,11 @@
         },
         "tags": [
           "Pedigrees"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
         ]
       }
     },
@@ -938,6 +2145,11 @@
         },
         "tags": [
           "Pedigrees"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
         ]
       }
     },
@@ -966,6 +2178,313 @@
         },
         "tags": [
           "Pedigrees"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/print-templates/categories": {
+      "get": {
+        "operationId": "PrintTemplatesController_getCategories",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      },
+      "post": {
+        "operationId": "PrintTemplatesController_createCategory",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreatePrintDocCategoryDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/print-templates/categories/{id}": {
+      "get": {
+        "operationId": "PrintTemplatesController_getCategory",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      },
+      "patch": {
+        "operationId": "PrintTemplatesController_updateCategory",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdatePrintDocCategoryDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "PrintTemplatesController_removeCategory",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/print-templates/data-sources": {
+      "get": {
+        "operationId": "PrintTemplatesController_getDataSources",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/print-templates": {
+      "get": {
+        "operationId": "PrintTemplatesController_findAll",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      },
+      "post": {
+        "operationId": "PrintTemplatesController_create",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreatePrintTemplateDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/print-templates/{id}": {
+      "get": {
+        "operationId": "PrintTemplatesController_findOne",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      },
+      "patch": {
+        "operationId": "PrintTemplatesController_update",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdatePrintTemplateDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "PrintTemplatesController_remove",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/print-templates/{id}/duplicate": {
+      "post": {
+        "operationId": "PrintTemplatesController_duplicate",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DuplicatePrintTemplateDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
         ]
       }
     },
@@ -1025,6 +2544,7 @@
             "in": "query",
             "description": "1ページあたりの件数",
             "schema": {
+              "maximum": 1000,
               "default": 50,
               "example": 50,
               "type": "number"
@@ -1065,6 +2585,36 @@
         "responses": {
           "200": {
             "description": "品種データの一覧"
+          }
+        },
+        "tags": [
+          "Breeds"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/breeds/master-data": {
+      "get": {
+        "operationId": "BreedsController_getMasterData",
+        "summary": "Pedigree連携用の品種マスターデータを取得",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "CSV マスターデータを displayName / displayNameMode 付きで返却",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/MasterDataItemDto"
+                  }
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -1211,6 +2761,54 @@
         ]
       }
     },
+    "/api/v1/display-preferences/me": {
+      "get": {
+        "operationId": "DisplayPreferencesController_getMine",
+        "summary": "自身の表示設定を取得",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "表示設定の取得に成功"
+          }
+        },
+        "tags": [
+          "Display Preferences"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      },
+      "patch": {
+        "operationId": "DisplayPreferencesController_updateMine",
+        "summary": "自身の表示設定を更新",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateDisplayPreferenceDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "表示設定の更新に成功"
+          }
+        },
+        "tags": [
+          "Display Preferences"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
     "/api/v1/coat-colors": {
       "post": {
         "operationId": "CoatColorsController_create",
@@ -1267,6 +2865,7 @@
             "in": "query",
             "description": "1ページあたりの件数",
             "schema": {
+              "maximum": 1000,
               "default": 50,
               "example": 50,
               "type": "number"
@@ -1307,6 +2906,36 @@
         "responses": {
           "200": {
             "description": "毛色データの一覧"
+          }
+        },
+        "tags": [
+          "Coat Colors"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/coat-colors/master-data": {
+      "get": {
+        "operationId": "CoatColorsController_getMasterData",
+        "summary": "Pedigree連携用の色柄マスターデータを取得",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "CSV マスターデータを displayName / displayNameMode 付きで返却",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/MasterDataItemDto"
+                  }
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -1542,6 +3171,11 @@
         },
         "tags": [
           "Breeding"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
         ]
       },
       "post": {
@@ -1687,21 +3321,6 @@
         ]
       }
     },
-    "/api/v1/breeding/test": {
-      "get": {
-        "operationId": "BreedingController_test",
-        "summary": "テスト",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "tags": [
-          "Breeding"
-        ]
-      }
-    },
     "/api/v1/breeding/pregnancy-checks": {
       "get": {
         "operationId": "BreedingController_findAllPregnancyChecks",
@@ -1759,6 +3378,11 @@
         },
         "tags": [
           "Breeding"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
         ]
       },
       "post": {
@@ -1913,6 +3537,11 @@
         },
         "tags": [
           "Breeding"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
         ]
       },
       "post": {
@@ -2031,6 +3660,11 @@
         },
         "tags": [
           "Breeding"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
         ]
       }
     },
@@ -2056,6 +3690,11 @@
         },
         "tags": [
           "Breeding"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
         ]
       }
     },
@@ -2090,6 +3729,11 @@
         },
         "tags": [
           "Breeding"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
         ]
       },
       "delete": {
@@ -2112,6 +3756,11 @@
         },
         "tags": [
           "Breeding"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
         ]
       }
     },
@@ -2136,6 +3785,395 @@
         },
         "tags": [
           "Breeding"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/breeding/schedules": {
+      "get": {
+        "operationId": "BreedingController_findAllBreedingSchedules",
+        "summary": "交配スケジュール一覧の取得",
+        "parameters": [
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "description": "ページ番号",
+            "schema": {
+              "default": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "description": "1ページあたりの件数",
+            "schema": {
+              "default": 50,
+              "type": "number"
+            }
+          },
+          {
+            "name": "maleId",
+            "required": false,
+            "in": "query",
+            "description": "オス猫IDでフィルタ",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "femaleId",
+            "required": false,
+            "in": "query",
+            "description": "メス猫IDでフィルタ",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "status",
+            "required": false,
+            "in": "query",
+            "description": "ステータスでフィルタ",
+            "schema": {
+              "enum": [
+                "SCHEDULED",
+                "IN_PROGRESS",
+                "COMPLETED",
+                "CANCELLED"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "name": "dateFrom",
+            "required": false,
+            "in": "query",
+            "description": "開始日（from）",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "dateTo",
+            "required": false,
+            "in": "query",
+            "description": "開始日（to）",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Breeding"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      },
+      "post": {
+        "operationId": "BreedingController_createBreedingSchedule",
+        "summary": "交配スケジュールの作成",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateBreedingScheduleDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Breeding"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/breeding/schedules/{id}": {
+      "patch": {
+        "operationId": "BreedingController_updateBreedingSchedule",
+        "summary": "交配スケジュールの更新",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateBreedingScheduleDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Breeding"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "BreedingController_removeBreedingSchedule",
+        "summary": "交配スケジュールの削除",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Breeding"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/breeding/schedules/{scheduleId}/checks": {
+      "get": {
+        "operationId": "BreedingController_findMatingChecks",
+        "summary": "交配チェック一覧の取得",
+        "parameters": [
+          {
+            "name": "scheduleId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Breeding"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      },
+      "post": {
+        "operationId": "BreedingController_createMatingCheck",
+        "summary": "交配チェックの追加",
+        "parameters": [
+          {
+            "name": "scheduleId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateMatingCheckDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Breeding"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/breeding/mating-checks/{id}": {
+      "patch": {
+        "operationId": "BreedingController_updateMatingCheck",
+        "summary": "交配チェックの更新",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateMatingCheckDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Breeding"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "BreedingController_removeMatingCheck",
+        "summary": "交配チェックの削除",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Breeding"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/breeding/{id}": {
+      "patch": {
+        "operationId": "BreedingController_update",
+        "summary": "交配記録の更新",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateBreedingDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Breeding"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "BreedingController_remove",
+        "summary": "交配記録の削除",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Breeding"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
         ]
       }
     },
@@ -2429,19 +4467,12 @@
             }
           },
           {
-            "name": "visitType",
+            "name": "visitTypeId",
             "required": false,
             "in": "query",
+            "description": "受診種別ID",
             "schema": {
-              "example": "CHECKUP",
-              "enum": [
-                "CHECKUP",
-                "EMERGENCY",
-                "SURGERY",
-                "FOLLOW_UP",
-                "VACCINATION",
-                "OTHER"
-              ],
+              "example": "c4a52a14-8d93-4b87-9f8c-7a6c2ef81234",
               "type": "string"
             }
           },
@@ -2519,6 +4550,111 @@
                 }
               }
             }
+          }
+        },
+        "tags": [
+          "Care"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/care/medical-records/{id}": {
+      "get": {
+        "operationId": "CareController_findMedicalRecordById",
+        "summary": "医療記録の詳細取得",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "医療記録ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MedicalRecordResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Care"
+        ]
+      },
+      "patch": {
+        "operationId": "CareController_updateMedicalRecord",
+        "summary": "医療記録の更新",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "医療記録ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateMedicalRecordDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MedicalRecordResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Care"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "CareController_deleteMedicalRecord",
+        "summary": "医療記録の削除",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "医療記録ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "削除成功"
           }
         },
         "tags": [
@@ -3373,7 +5509,12 @@
           "201": {
             "description": ""
           }
-        }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
       },
       "get": {
         "operationId": "StaffController_findAll",
@@ -3382,7 +5523,12 @@
           "200": {
             "description": ""
           }
-        }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
       }
     },
     "/api/v1/staff/{id}": {
@@ -3402,7 +5548,12 @@
           "200": {
             "description": ""
           }
-        }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
       },
       "patch": {
         "operationId": "StaffController_update",
@@ -3430,7 +5581,12 @@
           "200": {
             "description": ""
           }
-        }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
       },
       "delete": {
         "operationId": "StaffController_remove",
@@ -3448,7 +5604,12 @@
           "200": {
             "description": ""
           }
-        }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
       }
     },
     "/api/v1/staff/{id}/restore": {
@@ -3468,7 +5629,12 @@
           "200": {
             "description": ""
           }
-        }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
       }
     },
     "/api/v1/shifts": {
@@ -3489,7 +5655,12 @@
           "201": {
             "description": ""
           }
-        }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
       },
       "get": {
         "operationId": "ShiftController_findAll",
@@ -3498,7 +5669,12 @@
           "200": {
             "description": ""
           }
-        }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
       }
     },
     "/api/v1/shifts/calendar": {
@@ -3509,7 +5685,12 @@
           "200": {
             "description": ""
           }
-        }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
       }
     },
     "/api/v1/shifts/{id}": {
@@ -3529,7 +5710,12 @@
           "200": {
             "description": ""
           }
-        }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
       },
       "patch": {
         "operationId": "ShiftController_update",
@@ -3557,7 +5743,12 @@
           "200": {
             "description": ""
           }
-        }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
       },
       "delete": {
         "operationId": "ShiftController_remove",
@@ -3575,7 +5766,897 @@
           "200": {
             "description": ""
           }
-        }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/graduations/cats/{id}/transfer": {
+      "post": {
+        "operationId": "GraduationController_transferCat",
+        "summary": "猫を譲渡（卒業）する",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "猫ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TransferCatDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "譲渡成功"
+          },
+          "400": {
+            "description": "すでに卒業済みです"
+          },
+          "404": {
+            "description": "猫が見つかりません"
+          }
+        },
+        "tags": [
+          "Graduation"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/graduations": {
+      "get": {
+        "operationId": "GraduationController_findAllGraduations",
+        "summary": "卒業猫一覧取得",
+        "parameters": [
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "卒業猫一覧"
+          }
+        },
+        "tags": [
+          "Graduation"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/graduations/{id}": {
+      "get": {
+        "operationId": "GraduationController_findOneGraduation",
+        "summary": "卒業猫詳細取得",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "卒業ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "卒業猫詳細"
+          },
+          "404": {
+            "description": "卒業記録が見つかりません"
+          }
+        },
+        "tags": [
+          "Graduation"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      },
+      "patch": {
+        "operationId": "GraduationController_updateGraduation",
+        "summary": "卒業記録の更新",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "卒業ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateGraduationDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "更新成功"
+          },
+          "404": {
+            "description": "卒業記録が見つかりません"
+          }
+        },
+        "tags": [
+          "Graduation"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "GraduationController_cancelGraduation",
+        "summary": "卒業取り消し（緊急時用）",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "卒業ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "卒業取り消し成功"
+          },
+          "404": {
+            "description": "卒業記録が見つかりません"
+          }
+        },
+        "tags": [
+          "Graduation"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/gallery/upload/signed-url": {
+      "post": {
+        "operationId": "GalleryUploadController_generateUploadUrl",
+        "summary": "アップロード用Signed URLを生成",
+        "description": "クライアントがGCSへ直接アップロードするためのSigned URLを発行します。有効期限は15分です。",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GenerateUploadUrlDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Signed URL生成成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "uploadUrl": {
+                          "type": "string",
+                          "description": "アップロード用Signed URL"
+                        },
+                        "fileKey": {
+                          "type": "string",
+                          "description": "GCS内のファイルキー"
+                        },
+                        "publicUrl": {
+                          "type": "string",
+                          "description": "アップロード後の公開URL"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "パラメータエラー"
+          }
+        },
+        "tags": [
+          "Gallery Upload"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/gallery/upload/confirm": {
+      "post": {
+        "operationId": "GalleryUploadController_confirmUpload",
+        "summary": "アップロード完了を確認",
+        "description": "クライアントがGCSへアップロード完了後に呼び出し、ファイルの存在を確認します。",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConfirmUploadDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "確認成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "example": true
+                        },
+                        "url": {
+                          "type": "string",
+                          "description": "ファイルの公開URL"
+                        },
+                        "size": {
+                          "type": "number",
+                          "description": "ファイルサイズ（バイト）"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "ファイルが見つからない"
+          }
+        },
+        "tags": [
+          "Gallery Upload"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/gallery/upload/{fileKey}": {
+      "delete": {
+        "operationId": "GalleryUploadController_deleteFile",
+        "summary": "アップロード済みファイルを削除",
+        "description": "指定されたファイルキーのファイルをGCSから削除します。",
+        "parameters": [
+          {
+            "name": "fileKey",
+            "required": true,
+            "in": "path",
+            "description": "削除するファイルのキー（URLエンコード済み）",
+            "schema": {
+              "example": "gallery%2F550e8400-e29b-41d4-a716-446655440000.jpg",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "削除成功"
+          }
+        },
+        "tags": [
+          "Gallery Upload"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/gallery": {
+      "get": {
+        "operationId": "GalleryController_findAll",
+        "summary": "ギャラリーエントリ一覧取得",
+        "parameters": [
+          {
+            "name": "category",
+            "required": false,
+            "in": "query",
+            "description": "カテゴリでフィルタリング",
+            "schema": {
+              "enum": [
+                "KITTEN",
+                "FATHER",
+                "MOTHER",
+                "GRADUATION"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "description": "ページ番号",
+            "schema": {
+              "default": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "description": "1ページあたりの件数",
+            "schema": {
+              "default": 20,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ギャラリー一覧"
+          }
+        },
+        "tags": [
+          "Gallery"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      },
+      "post": {
+        "operationId": "GalleryController_create",
+        "summary": "ギャラリーエントリ作成",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateGalleryEntryDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "作成成功"
+          }
+        },
+        "tags": [
+          "Gallery"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/gallery/{id}": {
+      "get": {
+        "operationId": "GalleryController_findOne",
+        "summary": "ギャラリーエントリ詳細取得",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "エントリID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ギャラリー詳細"
+          },
+          "404": {
+            "description": "エントリが見つかりません"
+          }
+        },
+        "tags": [
+          "Gallery"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      },
+      "put": {
+        "operationId": "GalleryController_update",
+        "summary": "ギャラリーエントリ更新",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "エントリID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateGalleryEntryDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "更新成功"
+          },
+          "404": {
+            "description": "エントリが見つかりません"
+          }
+        },
+        "tags": [
+          "Gallery"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "GalleryController_delete",
+        "summary": "ギャラリーエントリ削除",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "エントリID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "削除成功"
+          },
+          "404": {
+            "description": "エントリが見つかりません"
+          }
+        },
+        "tags": [
+          "Gallery"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/gallery/{id}/media": {
+      "post": {
+        "operationId": "GalleryController_addMedia",
+        "summary": "メディア追加",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "エントリID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddMediaDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "メディア追加成功"
+          }
+        },
+        "tags": [
+          "Gallery"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/gallery/media/{mediaId}": {
+      "delete": {
+        "operationId": "GalleryController_deleteMedia",
+        "summary": "メディア削除",
+        "parameters": [
+          {
+            "name": "mediaId",
+            "required": true,
+            "in": "path",
+            "description": "メディアID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "メディア削除成功"
+          }
+        },
+        "tags": [
+          "Gallery"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/gallery/bulk": {
+      "post": {
+        "operationId": "GalleryController_bulkCreate",
+        "summary": "一括登録（子育て中タブ用）",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "一括登録成功"
+          }
+        },
+        "tags": [
+          "Gallery"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/export": {
+      "post": {
+        "operationId": "ExportController_export",
+        "summary": "データをエクスポート",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExportRequestDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "エクスポート成功"
+          },
+          "400": {
+            "description": "無効なリクエスト"
+          }
+        },
+        "tags": [
+          "Export"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/import/preview": {
+      "post": {
+        "operationId": "ImportController_preview",
+        "summary": "インポートファイルのプレビュー",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary",
+                    "description": "CSVファイル"
+                  }
+                },
+                "required": [
+                  "file"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "プレビュー取得成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportPreviewDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "ファイルが不正な形式"
+          },
+          "401": {
+            "description": "認証が必要"
+          }
+        },
+        "tags": [
+          "Import"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/import/cats": {
+      "post": {
+        "operationId": "ImportController_importCats",
+        "summary": "猫データのインポート",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary",
+                    "description": "CSVファイル（カラム: name, gender, birthDate, breed, color, registrationNumber, microchipNumber, notes）"
+                  }
+                },
+                "required": [
+                  "file"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "インポート完了",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportResultDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "ファイルが不正な形式"
+          },
+          "401": {
+            "description": "認証が必要"
+          }
+        },
+        "tags": [
+          "Import"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/import/pedigrees": {
+      "post": {
+        "operationId": "ImportController_importPedigrees",
+        "summary": "血統書データのインポート",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary",
+                    "description": "CSVファイル（カラム: pedigreeId, catName, title, breedCode, genderCode, coatColorCode）"
+                  }
+                },
+                "required": [
+                  "file"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "インポート完了",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportResultDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "ファイルが不正な形式"
+          },
+          "401": {
+            "description": "認証が必要"
+          }
+        },
+        "tags": [
+          "Import"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/import/tags": {
+      "post": {
+        "operationId": "ImportController_importTags",
+        "summary": "タグデータのインポート",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary",
+                    "description": "CSVファイル（カラム: name, category, group, color, isActive）"
+                  }
+                },
+                "required": [
+                  "file"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "インポート完了",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportResultDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "ファイルが不正な形式"
+          },
+          "401": {
+            "description": "認証が必要"
+          }
+        },
+        "tags": [
+          "Import"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
       }
     }
   },
@@ -3678,6 +6759,252 @@
           }
         }
       },
+      "UpdateProfileDto": {
+        "type": "object",
+        "properties": {
+          "firstName": {
+            "type": "string",
+            "description": "名",
+            "example": "太郎",
+            "maxLength": 100
+          },
+          "lastName": {
+            "type": "string",
+            "description": "姓",
+            "example": "山田",
+            "maxLength": 100
+          },
+          "email": {
+            "type": "string",
+            "description": "メールアドレス",
+            "example": "user@example.com"
+          }
+        }
+      },
+      "InviteUserDto": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "description": "招待するメールアドレス",
+            "example": "user@example.com"
+          },
+          "role": {
+            "type": "string",
+            "description": "ユーザーロール",
+            "enum": [
+              "USER",
+              "ADMIN",
+              "SUPER_ADMIN",
+              "TENANT_ADMIN"
+            ],
+            "default": "USER"
+          }
+        },
+        "required": [
+          "email",
+          "role"
+        ]
+      },
+      "UpdateUserRoleDto": {
+        "type": "object",
+        "properties": {
+          "role": {
+            "type": "string",
+            "description": "新しいロール",
+            "enum": [
+              "USER",
+              "ADMIN",
+              "SUPER_ADMIN",
+              "TENANT_ADMIN"
+            ],
+            "example": "ADMIN"
+          }
+        },
+        "required": [
+          "role"
+        ]
+      },
+      "CreateTenantDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "テナント名",
+            "example": "サンプルテナント"
+          },
+          "slug": {
+            "type": "string",
+            "description": "テナントスラッグ（未入力の場合は自動生成）",
+            "example": "sample-tenant"
+          }
+        },
+        "required": [
+          "name"
+        ]
+      },
+      "UpdateTenantDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "テナント名",
+            "example": "更新後テナント名"
+          },
+          "slug": {
+            "type": "string",
+            "description": "テナントスラッグ",
+            "example": "updated-tenant"
+          },
+          "isActive": {
+            "type": "boolean",
+            "description": "有効/無効フラグ",
+            "example": true
+          }
+        }
+      },
+      "InviteTenantAdminDto": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "description": "招待するメールアドレス",
+            "example": "admin@example.com"
+          },
+          "tenantName": {
+            "type": "string",
+            "description": "テナント名",
+            "example": "Sample Tenant"
+          },
+          "tenantSlug": {
+            "type": "string",
+            "description": "テナントスラッグ（URL識別子）",
+            "example": "sample-tenant"
+          }
+        },
+        "required": [
+          "email",
+          "tenantName"
+        ]
+      },
+      "CompleteInvitationDto": {
+        "type": "object",
+        "properties": {
+          "token": {
+            "type": "string",
+            "description": "招待トークン"
+          },
+          "password": {
+            "type": "string",
+            "description": "パスワード",
+            "minLength": 8
+          },
+          "firstName": {
+            "type": "string",
+            "description": "名"
+          },
+          "lastName": {
+            "type": "string",
+            "description": "姓"
+          }
+        },
+        "required": [
+          "token",
+          "password"
+        ]
+      },
+      "ColorSettingDto": {
+        "type": "object",
+        "properties": {
+          "color": {
+            "type": "string",
+            "description": "背景カラー（16進数カラーコード）",
+            "example": "#6366F1"
+          },
+          "textColor": {
+            "type": "string",
+            "description": "テキストカラー（16進数カラーコード）",
+            "example": "#111827"
+          }
+        },
+        "required": [
+          "color",
+          "textColor"
+        ]
+      },
+      "TagColorDefaultsDto": {
+        "type": "object",
+        "properties": {
+          "category": {
+            "description": "カテゴリのデフォルトカラー設定",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ColorSettingDto"
+              }
+            ]
+          },
+          "group": {
+            "description": "グループのデフォルトカラー設定",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ColorSettingDto"
+              }
+            ]
+          },
+          "tag": {
+            "description": "タグのデフォルトカラー設定",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ColorSettingDto"
+              }
+            ]
+          }
+        }
+      },
+      "PartialColorSettingDto": {
+        "type": "object",
+        "properties": {
+          "color": {
+            "type": "string",
+            "description": "背景カラー（16進数カラーコード）",
+            "example": "#6366F1"
+          },
+          "textColor": {
+            "type": "string",
+            "description": "テキストカラー（16進数カラーコード）",
+            "example": "#111827"
+          }
+        }
+      },
+      "UpdateTagColorDefaultsDto": {
+        "type": "object",
+        "properties": {
+          "category": {
+            "description": "カテゴリのデフォルトカラー設定（部分更新可能）",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PartialColorSettingDto"
+              }
+            ]
+          },
+          "group": {
+            "description": "グループのデフォルトカラー設定（部分更新可能）",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PartialColorSettingDto"
+              }
+            ]
+          },
+          "tag": {
+            "description": "タグのデフォルトカラー設定（部分更新可能）",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PartialColorSettingDto"
+              }
+            ]
+          }
+        }
+      },
       "CreateCatDto": {
         "type": "object",
         "properties": {
@@ -3751,6 +7078,100 @@
       "UpdateCatDto": {
         "type": "object",
         "properties": {}
+      },
+      "CreateWeightRecordDto": {
+        "type": "object",
+        "properties": {
+          "weight": {
+            "type": "number",
+            "description": "体重（グラム単位）",
+            "example": 350,
+            "minimum": 1,
+            "maximum": 50000
+          },
+          "recordedAt": {
+            "type": "string",
+            "description": "記録日時（省略時は現在日時）",
+            "example": "2024-01-15T10:00:00.000Z"
+          },
+          "notes": {
+            "type": "string",
+            "description": "メモ",
+            "example": "ミルクをよく飲んでいる"
+          }
+        },
+        "required": [
+          "weight"
+        ]
+      },
+      "UpdateWeightRecordDto": {
+        "type": "object",
+        "properties": {
+          "weight": {
+            "type": "number",
+            "description": "体重（グラム単位）",
+            "example": 380,
+            "minimum": 1,
+            "maximum": 50000
+          },
+          "recordedAt": {
+            "type": "string",
+            "description": "記録日時",
+            "example": "2024-01-15T10:00:00.000Z"
+          },
+          "notes": {
+            "type": "string",
+            "description": "メモ",
+            "example": "順調に成長中"
+          }
+        }
+      },
+      "BulkWeightRecordItemDto": {
+        "type": "object",
+        "properties": {
+          "catId": {
+            "type": "string",
+            "description": "猫ID",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "weight": {
+            "type": "number",
+            "description": "体重（グラム単位）",
+            "example": 350,
+            "minimum": 1,
+            "maximum": 50000
+          },
+          "notes": {
+            "type": "string",
+            "description": "メモ",
+            "example": "元気"
+          }
+        },
+        "required": [
+          "catId",
+          "weight"
+        ]
+      },
+      "CreateBulkWeightRecordsDto": {
+        "type": "object",
+        "properties": {
+          "recordedAt": {
+            "type": "string",
+            "description": "記録日時（全レコード共通）",
+            "example": "2024-01-15T10:00:00.000Z"
+          },
+          "records": {
+            "description": "体重記録の配列",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BulkWeightRecordItemDto"
+            }
+          }
+        },
+        "required": [
+          "recordedAt",
+          "records"
+        ]
       },
       "CreatePedigreeDto": {
         "type": "object",
@@ -4099,6 +7520,65 @@
         "type": "object",
         "properties": {}
       },
+      "CreatePrintDocCategoryDto": {
+        "type": "object",
+        "properties": {}
+      },
+      "UpdatePrintDocCategoryDto": {
+        "type": "object",
+        "properties": {}
+      },
+      "CreatePrintTemplateDto": {
+        "type": "object",
+        "properties": {}
+      },
+      "DuplicatePrintTemplateDto": {
+        "type": "object",
+        "properties": {}
+      },
+      "UpdatePrintTemplateDto": {
+        "type": "object",
+        "properties": {}
+      },
+      "MasterDataItemDto": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "number",
+            "description": "マスターデータのコード",
+            "example": 26
+          },
+          "name": {
+            "type": "string",
+            "description": "CSV 定義のデフォルト名称",
+            "example": "Maine Coon"
+          },
+          "displayName": {
+            "type": "string",
+            "description": "画面に表示される名称。個別設定が無い場合は name と同一。",
+            "example": "26 - Maine Coon"
+          },
+          "displayNameMode": {
+            "type": "string",
+            "enum": [
+              "CANONICAL",
+              "CODE_AND_NAME",
+              "CUSTOM"
+            ],
+            "description": "このレコードに適用された表示モード",
+            "example": "CODE_AND_NAME"
+          },
+          "isOverridden": {
+            "type": "boolean",
+            "description": "ユーザー上書きが適用された場合に true",
+            "example": true
+          }
+        },
+        "required": [
+          "code",
+          "name"
+        ]
+      },
       "CreateBreedDto": {
         "type": "object",
         "properties": {
@@ -4123,6 +7603,58 @@
       "UpdateBreedDto": {
         "type": "object",
         "properties": {}
+      },
+      "LabelOverrideDto": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "number",
+            "description": "対象コード",
+            "example": 26
+          },
+          "label": {
+            "type": "string",
+            "description": "表示名の上書き",
+            "example": "メインクーン"
+          }
+        }
+      },
+      "UpdateDisplayPreferenceDto": {
+        "type": "object",
+        "properties": {
+          "breedNameMode": {
+            "type": "string",
+            "enum": [
+              "CANONICAL",
+              "CODE_AND_NAME",
+              "CUSTOM"
+            ],
+            "description": "品種マスタの表示モード"
+          },
+          "coatColorNameMode": {
+            "type": "string",
+            "enum": [
+              "CANONICAL",
+              "CODE_AND_NAME",
+              "CUSTOM"
+            ],
+            "description": "毛色マスタの表示モード"
+          },
+          "breedLabelOverrides": {
+            "description": "品種コードごとの表示名上書き",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LabelOverrideDto"
+            }
+          },
+          "coatColorLabelOverrides": {
+            "description": "毛色コードごとの表示名上書き",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LabelOverrideDto"
+            }
+          }
+        }
       },
       "CreateCoatColorDto": {
         "type": "object",
@@ -4551,6 +8083,121 @@
           }
         }
       },
+      "CreateBreedingScheduleDto": {
+        "type": "object",
+        "properties": {
+          "maleId": {
+            "type": "string",
+            "description": "オス猫ID"
+          },
+          "femaleId": {
+            "type": "string",
+            "description": "メス猫ID"
+          },
+          "startDate": {
+            "type": "string",
+            "description": "開始日 (ISO8601)"
+          },
+          "duration": {
+            "type": "number",
+            "description": "期間（日数）",
+            "minimum": 1,
+            "maximum": 14
+          },
+          "status": {
+            "type": "string",
+            "description": "ステータス",
+            "enum": [
+              "SCHEDULED",
+              "IN_PROGRESS",
+              "COMPLETED",
+              "CANCELLED"
+            ]
+          },
+          "notes": {
+            "type": "string",
+            "description": "メモ"
+          }
+        },
+        "required": [
+          "maleId",
+          "femaleId",
+          "startDate",
+          "duration"
+        ]
+      },
+      "UpdateBreedingScheduleDto": {
+        "type": "object",
+        "properties": {
+          "maleId": {
+            "type": "string",
+            "description": "オス猫ID"
+          },
+          "femaleId": {
+            "type": "string",
+            "description": "メス猫ID"
+          },
+          "startDate": {
+            "type": "string",
+            "description": "開始日 (ISO8601)"
+          },
+          "duration": {
+            "type": "number",
+            "description": "期間（日数）",
+            "minimum": 1,
+            "maximum": 14
+          },
+          "status": {
+            "type": "string",
+            "description": "ステータス",
+            "enum": [
+              "SCHEDULED",
+              "IN_PROGRESS",
+              "COMPLETED",
+              "CANCELLED"
+            ]
+          },
+          "notes": {
+            "type": "string",
+            "description": "メモ"
+          }
+        }
+      },
+      "CreateMatingCheckDto": {
+        "type": "object",
+        "properties": {
+          "checkDate": {
+            "type": "string",
+            "description": "チェック日 (ISO8601)"
+          },
+          "count": {
+            "type": "number",
+            "description": "チェック回数",
+            "default": 1
+          }
+        },
+        "required": [
+          "checkDate"
+        ]
+      },
+      "UpdateMatingCheckDto": {
+        "type": "object",
+        "properties": {
+          "checkDate": {
+            "type": "string",
+            "description": "チェック日 (ISO8601)"
+          },
+          "count": {
+            "type": "number",
+            "description": "チェック回数",
+            "default": 1
+          }
+        }
+      },
+      "UpdateBreedingDto": {
+        "type": "object",
+        "properties": {}
+      },
       "CareScheduleCatDto": {
         "type": "object",
         "properties": {
@@ -4585,10 +8232,12 @@
           },
           "remindAt": {
             "type": "string",
+            "nullable": true,
             "example": "2025-08-01T09:00:00.000Z"
           },
           "offsetValue": {
             "type": "number",
+            "nullable": true,
             "example": 2
           },
           "offsetUnit": {
@@ -4600,6 +8249,7 @@
               "WEEK",
               "MONTH"
             ],
+            "nullable": true,
             "example": "DAY"
           },
           "relativeTo": {
@@ -4609,6 +8259,7 @@
               "END_DATE",
               "CUSTOM_DATE"
             ],
+            "nullable": true,
             "example": "START_DATE"
           },
           "channel": {
@@ -4631,22 +8282,27 @@
               "YEARLY",
               "CUSTOM"
             ],
-            "example": "NONE"
+            "example": "NONE",
+            "nullable": true
           },
           "repeatInterval": {
             "type": "number",
+            "nullable": true,
             "example": 1
           },
           "repeatCount": {
             "type": "number",
+            "nullable": true,
             "example": 5
           },
           "repeatUntil": {
             "type": "string",
+            "nullable": true,
             "example": "2025-12-31T00:00:00.000Z"
           },
           "notes": {
             "type": "string",
+            "nullable": true,
             "example": "前日9時に通知"
           },
           "isActive": {
@@ -4682,6 +8338,7 @@
           },
           "parentId": {
             "type": "string",
+            "nullable": true,
             "example": "parent-tag-id"
           }
         },
@@ -4709,6 +8366,7 @@
           },
           "description": {
             "type": "string",
+            "nullable": true,
             "example": "毎年の定期健診"
           },
           "scheduleDate": {
@@ -4717,10 +8375,12 @@
           },
           "endDate": {
             "type": "string",
+            "nullable": true,
             "example": "2025-09-01T01:00:00.000Z"
           },
           "timezone": {
             "type": "string",
+            "nullable": true,
             "example": "Asia/Tokyo"
           },
           "scheduleType": {
@@ -4770,6 +8430,7 @@
           },
           "recurrenceRule": {
             "type": "string",
+            "nullable": true,
             "example": "FREQ=YEARLY;INTERVAL=1"
           },
           "assignedTo": {
@@ -5127,6 +8788,41 @@
           "data"
         ]
       },
+      "MedicalRecordVisitTypeDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "example": "c4a52a14-8d93-4b87-9f8c-7a6c2ef81234"
+          },
+          "key": {
+            "type": "object",
+            "example": "CHECKUP"
+          },
+          "name": {
+            "type": "string",
+            "example": "健康診断"
+          },
+          "description": {
+            "type": "object",
+            "example": "定期的な健康診断"
+          },
+          "displayOrder": {
+            "type": "number",
+            "example": 1
+          },
+          "isActive": {
+            "type": "boolean",
+            "example": true
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "displayOrder",
+          "isActive"
+        ]
+      },
       "MedicalRecordSymptomDto": {
         "type": "object",
         "properties": {
@@ -5135,7 +8831,7 @@
             "example": "くしゃみ"
           },
           "note": {
-            "type": "string",
+            "type": "object",
             "example": "1週間継続"
           }
         },
@@ -5151,7 +8847,7 @@
             "example": "抗生物質"
           },
           "dosage": {
-            "type": "string",
+            "type": "object",
             "example": "朝晩1錠"
           }
         },
@@ -5200,28 +8896,39 @@
             "type": "string",
             "example": "tag-123"
           },
-          "slug": {
-            "type": "string",
-            "example": "vaccination"
-          },
-          "label": {
+          "name": {
             "type": "string",
             "example": "ワクチン"
           },
-          "level": {
-            "type": "number",
-            "example": 1
+          "color": {
+            "type": "object",
+            "example": "#3B82F6"
           },
-          "parentId": {
+          "textColor": {
+            "type": "object",
+            "example": "#FFFFFF"
+          },
+          "groupId": {
             "type": "string",
-            "example": "parent-tag"
+            "example": "group-123"
+          },
+          "groupName": {
+            "type": "object",
+            "example": "医療"
+          },
+          "categoryId": {
+            "type": "object",
+            "example": "category-456"
+          },
+          "categoryName": {
+            "type": "object",
+            "example": "医療タグ"
           }
         },
         "required": [
           "id",
-          "slug",
-          "label",
-          "level"
+          "name",
+          "groupId"
         ]
       },
       "MedicalRecordAttachmentDto": {
@@ -5232,23 +8939,23 @@
             "example": "https://cdn.example.com/xray.png"
           },
           "description": {
-            "type": "string",
+            "type": "object",
             "example": "胸部レントゲン"
           },
           "fileName": {
-            "type": "string",
+            "type": "object",
             "example": "xray.png"
           },
           "fileType": {
-            "type": "string",
+            "type": "object",
             "example": "image/png"
           },
           "fileSize": {
-            "type": "number",
+            "type": "object",
             "example": 204800
           },
           "capturedAt": {
-            "type": "string",
+            "type": "object",
             "example": "2025-08-10T09:30:00.000Z"
           }
         },
@@ -5268,24 +8975,19 @@
             "example": "2025-08-10T00:00:00.000Z"
           },
           "visitType": {
-            "type": "string",
-            "enum": [
-              "CHECKUP",
-              "EMERGENCY",
-              "SURGERY",
-              "FOLLOW_UP",
-              "VACCINATION",
-              "OTHER"
-            ],
-            "example": "CHECKUP",
-            "nullable": true
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MedicalRecordVisitTypeDto"
+              }
+            ]
           },
           "hospitalName": {
-            "type": "string",
+            "type": "object",
             "example": "ねこクリニック東京"
           },
           "symptom": {
-            "type": "string",
+            "type": "object",
             "example": "くしゃみが止まらない"
           },
           "symptomDetails": {
@@ -5295,15 +8997,15 @@
             }
           },
           "diseaseName": {
-            "type": "string",
+            "type": "object",
             "example": "猫風邪"
           },
           "diagnosis": {
-            "type": "string",
+            "type": "object",
             "example": "猫風邪の兆候"
           },
           "treatmentPlan": {
-            "type": "string",
+            "type": "object",
             "example": "抗生物質を5日間投与"
           },
           "medications": {
@@ -5313,7 +9015,7 @@
             }
           },
           "followUpDate": {
-            "type": "string",
+            "type": "object",
             "example": "2025-08-13T00:00:00.000Z"
           },
           "status": {
@@ -5325,7 +9027,7 @@
             "example": "TREATING"
           },
           "notes": {
-            "type": "string",
+            "type": "object",
             "example": "食欲は戻ってきた"
           },
           "cat": {
@@ -5477,17 +9179,10 @@
             "description": "受診日",
             "example": "2025-08-10"
           },
-          "visitType": {
+          "visitTypeId": {
             "type": "string",
-            "enum": [
-              "CHECKUP",
-              "EMERGENCY",
-              "SURGERY",
-              "FOLLOW_UP",
-              "VACCINATION",
-              "OTHER"
-            ],
-            "example": "CHECKUP"
+            "description": "受診種別ID",
+            "example": "c4a52a14-8d93-4b87-9f8c-7a6c2ef81234"
           },
           "hospitalName": {
             "type": "string",
@@ -5538,8 +9233,8 @@
             "type": "string",
             "example": "食欲も戻りつつあり"
           },
-          "careTagIds": {
-            "description": "関連ケアタグID",
+          "tagIds": {
+            "description": "関連タグID",
             "type": "array",
             "items": {
               "type": "string"
@@ -5573,6 +9268,94 @@
           "success",
           "data"
         ]
+      },
+      "UpdateMedicalRecordDto": {
+        "type": "object",
+        "properties": {
+          "catId": {
+            "type": "string",
+            "description": "猫ID",
+            "example": "e7b6a7a7-2d7f-4b2f-9f3a-1c2b3d4e5f60"
+          },
+          "scheduleId": {
+            "type": "string",
+            "description": "スケジュールID",
+            "example": "a6f7e52f-4a3b-4a76-9870-1234567890ab"
+          },
+          "visitDate": {
+            "type": "string",
+            "description": "受診日",
+            "example": "2025-08-10"
+          },
+          "visitTypeId": {
+            "type": "string",
+            "description": "受診種別ID",
+            "example": "c4a52a14-8d93-4b87-9f8c-7a6c2ef81234"
+          },
+          "hospitalName": {
+            "type": "string",
+            "example": "ねこクリニック東京"
+          },
+          "symptom": {
+            "type": "string",
+            "example": "くしゃみが止まらない"
+          },
+          "symptomDetails": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MedicalRecordSymptomDto"
+            }
+          },
+          "diseaseName": {
+            "type": "string",
+            "example": "猫風邪"
+          },
+          "diagnosis": {
+            "type": "string",
+            "example": "猫風邪の兆候"
+          },
+          "treatmentPlan": {
+            "type": "string",
+            "example": "抗生物質を5日間投与"
+          },
+          "medications": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MedicalRecordMedicationDto"
+            }
+          },
+          "followUpDate": {
+            "type": "string",
+            "example": "2025-08-13"
+          },
+          "status": {
+            "type": "string",
+            "example": "TREATING",
+            "enum": [
+              "TREATING",
+              "COMPLETED"
+            ],
+            "default": "TREATING"
+          },
+          "notes": {
+            "type": "string",
+            "example": "食欲も戻りつつあり"
+          },
+          "tagIds": {
+            "description": "関連タグID",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "attachments": {
+            "description": "添付ファイル",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MedicalRecordAttachmentInputDto"
+            }
+          }
+        }
       },
       "CreateTagDto": {
         "type": "object",
@@ -5992,10 +9775,10 @@
           },
           "name": {
             "type": "string",
-            "description": "ルール名"
+            "description": "ルール名（未入力時は自動生成）"
           },
           "description": {
-            "type": "string",
+            "type": "object",
             "description": "ルールの説明"
           },
           "triggerType": {
@@ -6016,14 +9799,15 @@
               "PREGNANCY_CONFIRMED",
               "KITTEN_REGISTERED",
               "AGE_THRESHOLD",
+              "CUSTOM",
               "PAGE_ACTION",
-              "CUSTOM"
+              "TAG_ASSIGNED"
             ],
             "description": "イベントタイプ",
-            "example": "BREEDING_PLANNED"
+            "example": "PAGE_ACTION"
           },
           "scope": {
-            "type": "string",
+            "type": "object",
             "description": "適用範囲（スコープ）",
             "example": "breeding"
           },
@@ -6046,14 +9830,13 @@
               "tagIds": [
                 "tag-id-1",
                 "tag-id-2"
-              ]
+              ],
+              "actionType": "ASSIGN"
             }
           }
         },
         "required": [
-          "name",
-          "triggerType",
-          "eventType"
+          "triggerType"
         ]
       },
       "UpdateTagAutomationRuleDto": {
@@ -6065,10 +9848,10 @@
           },
           "name": {
             "type": "string",
-            "description": "ルール名"
+            "description": "ルール名（未入力時は自動生成）"
           },
           "description": {
-            "type": "string",
+            "type": "object",
             "description": "ルールの説明"
           },
           "triggerType": {
@@ -6089,14 +9872,15 @@
               "PREGNANCY_CONFIRMED",
               "KITTEN_REGISTERED",
               "AGE_THRESHOLD",
+              "CUSTOM",
               "PAGE_ACTION",
-              "CUSTOM"
+              "TAG_ASSIGNED"
             ],
             "description": "イベントタイプ",
-            "example": "BREEDING_PLANNED"
+            "example": "PAGE_ACTION"
           },
           "scope": {
-            "type": "string",
+            "type": "object",
             "description": "適用範囲（スコープ）",
             "example": "breeding"
           },
@@ -6119,7 +9903,8 @@
               "tagIds": [
                 "tag-id-1",
                 "tag-id-2"
-              ]
+              ],
+              "actionType": "ASSIGN"
             }
           }
         }
@@ -6139,6 +9924,390 @@
       "UpdateShiftDto": {
         "type": "object",
         "properties": {}
+      },
+      "TransferCatDto": {
+        "type": "object",
+        "properties": {
+          "transferDate": {
+            "type": "string",
+            "description": "譲渡日",
+            "example": "2025-11-11"
+          },
+          "destination": {
+            "type": "string",
+            "description": "譲渡先",
+            "example": "山田家"
+          },
+          "notes": {
+            "type": "string",
+            "description": "備考",
+            "example": "譲渡先は愛情深い家庭です"
+          }
+        },
+        "required": [
+          "transferDate",
+          "destination"
+        ]
+      },
+      "UpdateGraduationDto": {
+        "type": "object",
+        "properties": {
+          "transferDate": {
+            "type": "string",
+            "description": "譲渡日",
+            "example": "2025-11-11"
+          },
+          "destination": {
+            "type": "string",
+            "description": "譲渡先",
+            "example": "山田家"
+          },
+          "notes": {
+            "type": "string",
+            "description": "備考",
+            "example": "譲渡先は愛情深い家庭です"
+          }
+        }
+      },
+      "GenerateUploadUrlDto": {
+        "type": "object",
+        "properties": {
+          "fileName": {
+            "type": "string",
+            "description": "ファイル名",
+            "example": "kitten-photo-1.jpg"
+          },
+          "contentType": {
+            "type": "string",
+            "description": "コンテンツタイプ",
+            "enum": [
+              "image/jpeg",
+              "image/png",
+              "image/webp"
+            ],
+            "example": "image/jpeg"
+          },
+          "fileSize": {
+            "type": "number",
+            "description": "ファイルサイズ（バイト）",
+            "example": 1024000,
+            "minimum": 1,
+            "maximum": 10485760
+          }
+        },
+        "required": [
+          "fileName",
+          "contentType",
+          "fileSize"
+        ]
+      },
+      "ConfirmUploadDto": {
+        "type": "object",
+        "properties": {
+          "fileKey": {
+            "type": "string",
+            "description": "アップロード時に発行されたファイルキー",
+            "example": "gallery/550e8400-e29b-41d4-a716-446655440000.jpg"
+          },
+          "galleryEntryId": {
+            "type": "string",
+            "description": "紐付けるギャラリーエントリID（任意）",
+            "example": "550e8400-e29b-41d4-a716-446655440001"
+          }
+        },
+        "required": [
+          "fileKey"
+        ]
+      },
+      "CreateMediaDto": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "IMAGE",
+              "YOUTUBE"
+            ],
+            "description": "メディアタイプ"
+          },
+          "url": {
+            "type": "string",
+            "description": "メディアURL"
+          },
+          "thumbnailUrl": {
+            "type": "string",
+            "description": "サムネイルURL（YouTube用）"
+          },
+          "order": {
+            "type": "number",
+            "description": "表示順序"
+          }
+        },
+        "required": [
+          "type",
+          "url"
+        ]
+      },
+      "CreateGalleryEntryDto": {
+        "type": "object",
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "KITTEN",
+              "FATHER",
+              "MOTHER",
+              "GRADUATION"
+            ],
+            "description": "カテゴリ"
+          },
+          "name": {
+            "type": "string",
+            "description": "猫の名前"
+          },
+          "gender": {
+            "type": "string",
+            "description": "性別",
+            "enum": [
+              "MALE",
+              "FEMALE",
+              "NEUTER",
+              "SPAY"
+            ]
+          },
+          "coatColor": {
+            "type": "string",
+            "description": "毛色"
+          },
+          "breed": {
+            "type": "string",
+            "description": "品種"
+          },
+          "catId": {
+            "type": "string",
+            "description": "在舎猫ID（参照用）"
+          },
+          "transferDate": {
+            "type": "string",
+            "description": "譲渡日（卒業猫用）"
+          },
+          "destination": {
+            "type": "string",
+            "description": "譲渡先（卒業猫用）"
+          },
+          "externalLink": {
+            "type": "string",
+            "description": "外部リンク（卒業猫用）"
+          },
+          "notes": {
+            "type": "string",
+            "description": "備考"
+          },
+          "media": {
+            "description": "メディア（画像・動画）",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CreateMediaDto"
+            }
+          }
+        },
+        "required": [
+          "category",
+          "name",
+          "gender"
+        ]
+      },
+      "UpdateGalleryEntryDto": {
+        "type": "object",
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "KITTEN",
+              "FATHER",
+              "MOTHER",
+              "GRADUATION"
+            ],
+            "description": "カテゴリ"
+          },
+          "name": {
+            "type": "string",
+            "description": "猫の名前"
+          },
+          "gender": {
+            "type": "string",
+            "description": "性別",
+            "enum": [
+              "MALE",
+              "FEMALE",
+              "NEUTER",
+              "SPAY"
+            ]
+          },
+          "coatColor": {
+            "type": "string",
+            "description": "毛色"
+          },
+          "breed": {
+            "type": "string",
+            "description": "品種"
+          },
+          "catId": {
+            "type": "string",
+            "description": "在舎猫ID（参照用）"
+          },
+          "transferDate": {
+            "type": "string",
+            "description": "譲渡日（卒業猫用）"
+          },
+          "destination": {
+            "type": "string",
+            "description": "譲渡先（卒業猫用）"
+          },
+          "externalLink": {
+            "type": "string",
+            "description": "外部リンク（卒業猫用）"
+          },
+          "notes": {
+            "type": "string",
+            "description": "備考"
+          },
+          "media": {
+            "description": "メディア（画像・動画）",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CreateMediaDto"
+            }
+          }
+        }
+      },
+      "AddMediaDto": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "IMAGE",
+              "YOUTUBE"
+            ],
+            "description": "メディアタイプ"
+          },
+          "url": {
+            "type": "string",
+            "description": "メディアURL"
+          },
+          "thumbnailUrl": {
+            "type": "string",
+            "description": "サムネイルURL（YouTube用）"
+          }
+        },
+        "required": [
+          "type",
+          "url"
+        ]
+      },
+      "ExportRequestDto": {
+        "type": "object",
+        "properties": {
+          "dataType": {
+            "type": "string",
+            "enum": [
+              "cats",
+              "pedigrees",
+              "medical_records",
+              "care_schedules",
+              "tags"
+            ],
+            "description": "エクスポート対象データ種別"
+          },
+          "format": {
+            "type": "string",
+            "enum": [
+              "csv",
+              "json"
+            ],
+            "description": "エクスポート形式",
+            "default": "csv"
+          },
+          "startDate": {
+            "type": "string",
+            "description": "開始日（フィルタ用）"
+          },
+          "endDate": {
+            "type": "string",
+            "description": "終了日（フィルタ用）"
+          },
+          "ids": {
+            "description": "対象IDリスト（特定データのみエクスポート）",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "dataType",
+          "format"
+        ]
+      },
+      "ImportPreviewDto": {
+        "type": "object",
+        "properties": {
+          "previewCount": {
+            "type": "number",
+            "description": "プレビューデータ件数"
+          },
+          "sampleData": {
+            "type": "array",
+            "description": "サンプルデータ（最初の5件）"
+          },
+          "columns": {
+            "description": "検出されたカラム",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "totalCount": {
+            "type": "number",
+            "description": "データ総件数"
+          }
+        },
+        "required": [
+          "previewCount",
+          "sampleData",
+          "columns",
+          "totalCount"
+        ]
+      },
+      "ImportResultDto": {
+        "type": "object",
+        "properties": {
+          "successCount": {
+            "type": "number",
+            "description": "インポート成功件数"
+          },
+          "errorCount": {
+            "type": "number",
+            "description": "インポート失敗件数"
+          },
+          "totalCount": {
+            "type": "number",
+            "description": "処理総件数"
+          },
+          "errors": {
+            "description": "エラー詳細（最初の10件）",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "successCount",
+          "errorCount",
+          "totalCount"
+        ]
       }
     }
   }

--- a/backend/prisma/migrations/20260611135928_cat_deletion_snapshots/migration.sql
+++ b/backend/prisma/migrations/20260611135928_cat_deletion_snapshots/migration.sql
@@ -1,0 +1,71 @@
+-- DropForeignKey
+ALTER TABLE "birth_plans" DROP CONSTRAINT "birth_plans_mother_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "breeding_records" DROP CONSTRAINT "breeding_records_female_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "breeding_records" DROP CONSTRAINT "breeding_records_male_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "breeding_schedules" DROP CONSTRAINT "breeding_schedules_female_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "breeding_schedules" DROP CONSTRAINT "breeding_schedules_male_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "medical_records" DROP CONSTRAINT "medical_records_cat_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "pregnancy_checks" DROP CONSTRAINT "pregnancy_checks_mother_id_fkey";
+
+-- AlterTable
+ALTER TABLE "birth_plans" ADD COLUMN     "father_name" TEXT,
+ADD COLUMN     "mother_name" TEXT,
+ALTER COLUMN "mother_id" DROP NOT NULL;
+
+-- AlterTable
+ALTER TABLE "breeding_records" ADD COLUMN     "female_name" TEXT,
+ADD COLUMN     "male_name" TEXT,
+ALTER COLUMN "male_id" DROP NOT NULL,
+ALTER COLUMN "female_id" DROP NOT NULL;
+
+-- AlterTable
+ALTER TABLE "breeding_schedules" ADD COLUMN     "female_name" TEXT,
+ADD COLUMN     "male_name" TEXT,
+ALTER COLUMN "male_id" DROP NOT NULL,
+ALTER COLUMN "female_id" DROP NOT NULL;
+
+-- AlterTable
+ALTER TABLE "cats" ADD COLUMN     "father_name" TEXT,
+ADD COLUMN     "mother_name" TEXT;
+
+-- AlterTable
+ALTER TABLE "medical_records" ADD COLUMN     "cat_name" TEXT,
+ALTER COLUMN "cat_id" DROP NOT NULL;
+
+-- AlterTable
+ALTER TABLE "pregnancy_checks" ADD COLUMN     "father_name" TEXT,
+ADD COLUMN     "mother_name" TEXT,
+ALTER COLUMN "mother_id" DROP NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "breeding_records" ADD CONSTRAINT "breeding_records_female_id_fkey" FOREIGN KEY ("female_id") REFERENCES "cats"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "breeding_records" ADD CONSTRAINT "breeding_records_male_id_fkey" FOREIGN KEY ("male_id") REFERENCES "cats"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "breeding_schedules" ADD CONSTRAINT "breeding_schedules_male_id_fkey" FOREIGN KEY ("male_id") REFERENCES "cats"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "breeding_schedules" ADD CONSTRAINT "breeding_schedules_female_id_fkey" FOREIGN KEY ("female_id") REFERENCES "cats"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "pregnancy_checks" ADD CONSTRAINT "pregnancy_checks_mother_id_fkey" FOREIGN KEY ("mother_id") REFERENCES "cats"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "birth_plans" ADD CONSTRAINT "birth_plans_mother_id_fkey" FOREIGN KEY ("mother_id") REFERENCES "cats"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "medical_records" ADD CONSTRAINT "medical_records_cat_id_fkey" FOREIGN KEY ("cat_id") REFERENCES "cats"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -189,6 +189,9 @@ model Cat {
   description           String?                @map("notes")
   fatherId              String?                @map("father_id")
   motherId              String?                @map("mother_id")
+  /// 親猫削除後も名前をテキストで保持するスナップショット
+  fatherName            String?                @map("father_name")
+  motherName            String?                @map("mother_name")
   createdAt             DateTime               @default(now()) @map("created_at")
   updatedAt             DateTime               @updatedAt @map("updated_at")
   pedigreeId            String?                @map("pedigree_id")
@@ -241,8 +244,11 @@ model Cat {
 
 model BreedingRecord {
   id              String         @id @default(uuid())
-  maleId          String         @map("male_id")
-  femaleId        String         @map("female_id")
+  maleId          String?        @map("male_id")
+  femaleId        String?        @map("female_id")
+  /// 猫削除後も名前をテキストで保持するスナップショット
+  maleName        String?        @map("male_name")
+  femaleName      String?        @map("female_name")
   breedingDate    DateTime       @map("breeding_date")
   expectedDueDate DateTime?      @map("expected_due_date")
   actualDueDate   DateTime?      @map("actual_due_date")
@@ -252,8 +258,8 @@ model BreedingRecord {
   recordedBy      String         @map("recorded_by")
   createdAt       DateTime       @default(now()) @map("created_at")
   updatedAt       DateTime       @updatedAt @map("updated_at")
-  female          Cat            @relation("FemaleBreeding", fields: [femaleId], references: [id])
-  male            Cat            @relation("MaleBreeding", fields: [maleId], references: [id])
+  female          Cat?           @relation("FemaleBreeding", fields: [femaleId], references: [id])
+  male            Cat?           @relation("MaleBreeding", fields: [maleId], references: [id])
   recorder        User           @relation(fields: [recordedBy], references: [id])
 
   @@index([maleId])
@@ -288,8 +294,11 @@ model BreedingNgRule {
 // 交配スケジュール - 交配期間の管理
 model BreedingSchedule {
   id         String                  @id @default(uuid())
-  maleId     String                  @map("male_id")
-  femaleId   String                  @map("female_id")
+  maleId     String?                 @map("male_id")
+  femaleId   String?                 @map("female_id")
+  /// 猫削除後も名前をテキストで保持するスナップショット
+  maleName   String?                 @map("male_name")
+  femaleName String?                 @map("female_name")
   startDate  DateTime                @map("start_date")
   duration   Int                     // 日数
   status     BreedingScheduleStatus  @default(SCHEDULED)
@@ -298,8 +307,8 @@ model BreedingSchedule {
   createdAt  DateTime                @default(now()) @map("created_at")
   updatedAt  DateTime                @updatedAt @map("updated_at")
 
-  male       Cat                     @relation("BreedingScheduleMale", fields: [maleId], references: [id])
-  female     Cat                     @relation("BreedingScheduleFemale", fields: [femaleId], references: [id])
+  male       Cat?                    @relation("BreedingScheduleMale", fields: [maleId], references: [id])
+  female     Cat?                    @relation("BreedingScheduleFemale", fields: [femaleId], references: [id])
   recorder   User                    @relation(fields: [recordedBy], references: [id])
   checks     MatingCheck[]
 
@@ -342,10 +351,13 @@ model PregnancyCheck {
   recordedBy String          @map("recorded_by")
   createdAt  DateTime        @default(now()) @map("created_at")
   updatedAt  DateTime        @updatedAt @map("updated_at")
-  motherId   String          @map("mother_id")
+  motherId   String?         @map("mother_id")
   fatherId   String?         @map("father_id")
+  /// 猫削除後も名前をテキストで保持するスナップショット
+  motherName String?         @map("mother_name")
+  fatherName String?         @map("father_name")
   matingDate DateTime?       @map("mating_date")
-  mother     Cat             @relation("PregnancyCheckMother", fields: [motherId], references: [id])
+  mother     Cat?            @relation("PregnancyCheckMother", fields: [motherId], references: [id])
   recorder   User            @relation(fields: [recordedBy], references: [id])
 
   @@index([motherId])
@@ -369,11 +381,14 @@ model BirthPlan {
   actualKittens      Int?                @map("actual_kittens")
   expectedBirthDate  DateTime            @map("expected_birth_date")
   expectedKittens    Int?                @map("expected_kittens")
-  motherId           String              @map("mother_id")
+  motherId           String?             @map("mother_id")
   fatherId           String?             @map("father_id")
+  /// 猫削除後も名前をテキストで保持するスナップショット
+  motherName         String?             @map("mother_name")
+  fatherName         String?             @map("father_name")
   matingDate         DateTime?           @map("mating_date")
   completedAt        DateTime?           @map("completed_at")
-  mother             Cat                 @relation("BirthPlanMother", fields: [motherId], references: [id])
+  mother             Cat?                @relation("BirthPlanMother", fields: [motherId], references: [id])
   recorder           User                @relation(fields: [recordedBy], references: [id])
   kittenDispositions KittenDisposition[]
 
@@ -580,7 +595,9 @@ model MedicalVisitType {
 
 model MedicalRecord {
   id             String                    @id @default(uuid())
-  catId          String                    @map("cat_id")
+  catId          String?                   @map("cat_id")
+  /// 猫削除後も対象名をテキストで保持するスナップショット
+  catName        String?                   @map("cat_name")
   scheduleId     String?                   @map("schedule_id")
   recordedBy     String                    @map("recorded_by")
   visitDate      DateTime                  @map("visit_date")
@@ -599,7 +616,7 @@ model MedicalRecord {
   visitTypeId    String?                   @map("visit_type_id")
   attachments    MedicalRecordAttachment[]
   tags           MedicalRecordTag[]
-  cat            Cat                       @relation(fields: [catId], references: [id])
+  cat            Cat?                      @relation(fields: [catId], references: [id])
   recorder       User                      @relation(fields: [recordedBy], references: [id])
   schedule       Schedule?                 @relation(fields: [scheduleId], references: [id])
   visitType      MedicalVisitType?         @relation(fields: [visitTypeId], references: [id])

--- a/backend/src/breeding/breeding.service.ts
+++ b/backend/src/breeding/breeding.service.ts
@@ -63,6 +63,58 @@ export class BreedingService {
     });
   }
 
+  /**
+   * NGペアルールに違反していないか照合し、違反時は例外を投げる
+   * （force 指定時はスキップ。GENERATION_LIMIT は血統データ連携が未実装のため未対応）
+   */
+  private async assertNgRules(maleId: string, femaleId: string, force?: boolean): Promise<void> {
+    if (force) return;
+
+    const rules = await this.prisma.breedingNgRule.findMany({ where: { active: true } });
+    if (rules.length === 0) return;
+
+    const catSelect = {
+      name: true,
+      tags: { select: { tag: { select: { name: true } } } },
+    } as const;
+    const [male, female] = await Promise.all([
+      this.prisma.cat.findUnique({ where: { id: maleId }, select: catSelect }),
+      this.prisma.cat.findUnique({ where: { id: femaleId }, select: catSelect }),
+    ]);
+    if (!male || !female) return;
+
+    const maleTags = male.tags.map((catTag) => catTag.tag.name);
+    const femaleTags = female.tags.map((catTag) => catTag.tag.name);
+
+    for (const rule of rules) {
+      let violated = false;
+
+      if (
+        rule.type === 'TAG_COMBINATION' &&
+        rule.maleConditions.length > 0 &&
+        rule.femaleConditions.length > 0
+      ) {
+        violated =
+          rule.maleConditions.some((condition) => maleTags.includes(condition)) &&
+          rule.femaleConditions.some((condition) => femaleTags.includes(condition));
+      } else if (
+        rule.type === 'INDIVIDUAL_PROHIBITION' &&
+        rule.maleNames.length > 0 &&
+        rule.femaleNames.length > 0
+      ) {
+        violated =
+          rule.maleNames.includes(male.name) && rule.femaleNames.includes(female.name);
+      }
+
+      if (violated) {
+        const description = rule.description ? ` ${rule.description}` : '';
+        throw new BadRequestException(
+          `NGペアルール「${rule.name}」に該当するため登録できません。${description}強行する場合は force を指定してください`.trim(),
+        );
+      }
+    }
+  }
+
   async findAll(query: BreedingQueryDto): Promise<BreedingListResponse> {
     const {
       page = 1,
@@ -125,6 +177,9 @@ export class BreedingService {
 
     if (!female) throw new NotFoundException("femaleId not found");
     if (!male) throw new NotFoundException("maleId not found");
+
+    // NGペアルール照合（force 指定時はスキップ）
+    await this.assertNgRules(dto.maleId, dto.femaleId, dto.force);
 
     // Basic gender check (optional but useful)
     if ((female as CatWithGender).gender === "MALE") {
@@ -705,6 +760,9 @@ export class BreedingService {
     if (!recordedById) {
       throw new BadRequestException('記録者情報が取得できませんでした');
     }
+
+    // NGペアルール照合（force 指定時はスキップ）
+    await this.assertNgRules(dto.maleId, dto.femaleId, dto.force);
 
     const result = await this.prisma.breedingSchedule.create({
       data: {

--- a/backend/src/breeding/breeding.service.ts
+++ b/backend/src/breeding/breeding.service.ts
@@ -338,7 +338,9 @@ export class BreedingService {
         maleId: result.fatherId ?? undefined,
         confirmedDate: result.checkDate,
       });
-      this.emitPageActionEvent('pregnancy_confirmed', result.motherId);
+      if (result.motherId) {
+        this.emitPageActionEvent('pregnancy_confirmed', result.motherId);
+      }
       if (result.fatherId) {
         this.emitPageActionEvent('pregnancy_confirmed', result.fatherId);
       }
@@ -730,8 +732,12 @@ export class BreedingService {
       femaleId: result.femaleId,
       plannedDate: result.startDate,
     });
-    this.emitPageActionEvent('create', result.maleId);
-    this.emitPageActionEvent('create', result.femaleId);
+    if (result.maleId) {
+      this.emitPageActionEvent('create', result.maleId);
+    }
+    if (result.femaleId) {
+      this.emitPageActionEvent('create', result.femaleId);
+    }
 
     return { success: true, data: result };
   }

--- a/backend/src/breeding/breeding.service.ts
+++ b/backend/src/breeding/breeding.service.ts
@@ -1,7 +1,9 @@
 import { Injectable, BadRequestException, NotFoundException } from "@nestjs/common";
+import { EventEmitter2 } from "@nestjs/event-emitter";
 import { Prisma } from "@prisma/client";
 
 import { PrismaService } from "../prisma/prisma.service";
+import { TAG_AUTOMATION_EVENTS } from "../tags/events/tag-automation.events";
 
 import {
   BreedingQueryDto,
@@ -42,7 +44,24 @@ import {
 
 @Injectable()
 export class BreedingService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly eventEmitter: EventEmitter2,
+  ) {}
+
+  /**
+   * PAGE_ACTION タイプのタグ自動化ルール向けイベントを発火する
+   */
+  private emitPageActionEvent(action: string, catId: string): void {
+    this.eventEmitter.emit(TAG_AUTOMATION_EVENTS.PAGE_ACTION, {
+      eventType: "PAGE_ACTION" as const,
+      timestamp: new Date(),
+      page: "breeding",
+      action,
+      targetId: catId,
+      targetType: "cat",
+    });
+  }
 
   async findAll(query: BreedingQueryDto): Promise<BreedingListResponse> {
     const {
@@ -308,6 +327,22 @@ export class BreedingService {
         mother: { select: { id: true, name: true } },
       },
     });
+
+    // 妊娠確認イベントを発火（タグ自動化: PREGNANCY_CONFIRMED / breeding.pregnancy_confirmed）
+    if (result.status === 'CONFIRMED') {
+      this.eventEmitter.emit(TAG_AUTOMATION_EVENTS.PREGNANCY_CONFIRMED, {
+        eventType: 'PREGNANCY_CONFIRMED' as const,
+        timestamp: new Date(),
+        pregnancyCheckId: result.id,
+        femaleId: result.motherId,
+        maleId: result.fatherId ?? undefined,
+        confirmedDate: result.checkDate,
+      });
+      this.emitPageActionEvent('pregnancy_confirmed', result.motherId);
+      if (result.fatherId) {
+        this.emitPageActionEvent('pregnancy_confirmed', result.fatherId);
+      }
+    }
 
     return { success: true, data: result };
   }
@@ -685,6 +720,18 @@ export class BreedingService {
         checks: true,
       },
     });
+
+    // 交配予定イベントを発火（タグ自動化: BREEDING_PLANNED / breeding.create）
+    this.eventEmitter.emit(TAG_AUTOMATION_EVENTS.BREEDING_PLANNED, {
+      eventType: 'BREEDING_PLANNED' as const,
+      timestamp: new Date(),
+      breedingId: result.id,
+      maleId: result.maleId,
+      femaleId: result.femaleId,
+      plannedDate: result.startDate,
+    });
+    this.emitPageActionEvent('create', result.maleId);
+    this.emitPageActionEvent('create', result.femaleId);
 
     return { success: true, data: result };
   }

--- a/backend/src/breeding/dto/breeding-schedule.dto.ts
+++ b/backend/src/breeding/dto/breeding-schedule.dto.ts
@@ -13,6 +13,7 @@ import {
   Min,
   Max,
   IsUUID,
+  IsBoolean,
 } from 'class-validator';
 
 // Prisma の enum と同期
@@ -58,6 +59,14 @@ export class CreateBreedingScheduleDto {
   @IsOptional()
   @IsString()
   notes?: string;
+  @ApiPropertyOptional({
+    description: "NGペアルール違反時でも強行登録する場合に true",
+    example: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  force?: boolean;
+
 }
 
 /**

--- a/backend/src/breeding/dto/create-breeding.dto.ts
+++ b/backend/src/breeding/dto/create-breeding.dto.ts
@@ -4,6 +4,7 @@ import {
   IsOptional,
   IsString,
   IsUUID,
+  IsBoolean,
 } from "class-validator";
 
 export class CreateBreedingDto {
@@ -37,4 +38,12 @@ export class CreateBreedingDto {
   @IsOptional()
   @IsString()
   notes?: string;
+  @ApiPropertyOptional({
+    description: "NGペアルール違反時でも強行登録する場合に true",
+    example: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  force?: boolean;
+
 }

--- a/backend/src/breeding/types/breeding.types.ts
+++ b/backend/src/breeding/types/breeding.types.ts
@@ -15,8 +15,11 @@ export interface BreedingWhereInput {
 // Type for the Prisma select operations
 export type BreedingRecordWithRelations = {
   id: string;
-  maleId: string;
-  femaleId: string;
+  maleId: string | null;
+  /** 猫削除後のスナップショット名 */
+  maleName?: string | null;
+  femaleId: string | null;
+  femaleName?: string | null;
   breedingDate: Date;
   expectedDueDate: Date | null;
   actualDueDate: Date | null;
@@ -85,7 +88,10 @@ export interface BreedingNgRuleResponse {
 // Pregnancy Check types
 export type PregnancyCheckWithRelations = {
   id: string;
-  motherId: string;
+  motherId: string | null;
+  /** 猫削除後のスナップショット名 */
+  motherName?: string | null;
+  fatherName?: string | null;
   checkDate: Date;
   status: PregnancyStatus;
   notes: string | null;
@@ -113,7 +119,10 @@ export interface PregnancyCheckResponse {
 // Birth Plan types
 export type BirthPlanWithRelations = {
   id: string;
-  motherId: string;
+  motherId: string | null;
+  /** 猫削除後のスナップショット名 */
+  motherName?: string | null;
+  fatherName?: string | null;
   expectedBirthDate: Date;
   actualBirthDate: Date | null;
   status: BirthStatus;
@@ -146,8 +155,11 @@ export type BreedingScheduleStatus = 'SCHEDULED' | 'IN_PROGRESS' | 'COMPLETED' |
 
 export type BreedingScheduleWithRelations = {
   id: string;
-  maleId: string;
-  femaleId: string;
+  maleId: string | null;
+  /** 猫削除後のスナップショット名 */
+  maleName?: string | null;
+  femaleId: string | null;
+  femaleName?: string | null;
   startDate: Date;
   duration: number;
   status: BreedingScheduleStatus;

--- a/backend/src/care/care.controller.ts
+++ b/backend/src/care/care.controller.ts
@@ -34,6 +34,7 @@ import {
   MedicalRecordListResponseDto,
   MedicalRecordQueryDto,
   MedicalRecordResponseDto,
+  UpdateCareStatusDto,
   UpdateMedicalRecordDto,
 } from "./dto";
 
@@ -98,6 +99,19 @@ export class CareController {
   @ApiParam({ name: "id", description: "スケジュールID" })
   deleteSchedule(@Param("id") id: string) {
     return this.careService.deleteSchedule(id);
+  }
+
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @Patch("schedules/:id/status")
+  @ApiOperation({ summary: "ケアスケジュールのステータス変更（有効/無効）" })
+  @ApiParam({ name: "id", description: "スケジュールID" })
+  @ApiResponse({ status: HttpStatus.OK, type: CareScheduleResponseDto })
+  updateScheduleStatus(
+    @Param("id") id: string,
+    @Body() dto: UpdateCareStatusDto,
+  ) {
+    return this.careService.updateScheduleStatus(id, dto.status);
   }
 
   @Get("medical-records")

--- a/backend/src/care/care.controller.ts
+++ b/backend/src/care/care.controller.ts
@@ -133,6 +133,8 @@ export class CareController {
     return this.careService.addMedicalRecord(dto, user?.userId);
   }
 
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
   @Get("medical-records/:id")
   @ApiOperation({ summary: "医療記録の詳細取得" })
   @ApiParam({ name: "id", description: "医療記録ID" })

--- a/backend/src/care/care.controller.ts
+++ b/backend/src/care/care.controller.ts
@@ -34,6 +34,7 @@ import {
   MedicalRecordListResponseDto,
   MedicalRecordQueryDto,
   MedicalRecordResponseDto,
+  UpdateMedicalRecordDto,
 } from "./dto";
 
 @ApiTags("Care")
@@ -116,5 +117,36 @@ export class CareController {
     @GetUser() user?: RequestUser,
   ) {
     return this.careService.addMedicalRecord(dto, user?.userId);
+  }
+
+  @Get("medical-records/:id")
+  @ApiOperation({ summary: "医療記録の詳細取得" })
+  @ApiParam({ name: "id", description: "医療記録ID" })
+  @ApiResponse({ status: HttpStatus.OK, type: MedicalRecordResponseDto })
+  findMedicalRecordById(@Param("id") id: string) {
+    return this.careService.findMedicalRecordById(id);
+  }
+
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @Patch("medical-records/:id")
+  @ApiOperation({ summary: "医療記録の更新" })
+  @ApiParam({ name: "id", description: "医療記録ID" })
+  @ApiResponse({ status: HttpStatus.OK, type: MedicalRecordResponseDto })
+  updateMedicalRecord(
+    @Param("id") id: string,
+    @Body() dto: UpdateMedicalRecordDto,
+  ) {
+    return this.careService.updateMedicalRecord(id, dto);
+  }
+
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @Delete("medical-records/:id")
+  @ApiOperation({ summary: "医療記録の削除" })
+  @ApiParam({ name: "id", description: "医療記録ID" })
+  @ApiResponse({ status: HttpStatus.OK, description: "削除成功" })
+  deleteMedicalRecord(@Param("id") id: string) {
+    return this.careService.deleteMedicalRecord(id);
   }
 }

--- a/backend/src/care/care.service.spec.ts
+++ b/backend/src/care/care.service.spec.ts
@@ -298,4 +298,148 @@ describe('CareService', () => {
       await expect(service.deleteSchedule('invalid')).rejects.toThrow(NotFoundException);
     });
   });
+  describe('findMedicalRecordById', () => {
+    const mockRecord = {
+      id: 'rec-1',
+      catId: 'cat-1',
+      visitDate: new Date(),
+      diagnosis: 'Healthy',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      recordedBy: 'user-1',
+      status: 'COMPLETED',
+      cat: { id: 'cat-1', name: 'Test Cat' },
+      schedule: null,
+      tags: [],
+      attachments: [],
+    };
+
+    it('should return a medical record by id', async () => {
+      mockPrismaService.medicalRecord.findUnique.mockResolvedValue(mockRecord);
+
+      const result = await service.findMedicalRecordById('rec-1');
+
+      expect(result.success).toBe(true);
+      expect(result.data.id).toBe('rec-1');
+      expect(result.data.cat.id).toBe('cat-1');
+    });
+
+    it('should throw NotFoundException for invalid id', async () => {
+      mockPrismaService.medicalRecord.findUnique.mockResolvedValue(null);
+
+      await expect(service.findMedicalRecordById('invalid')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('updateMedicalRecord', () => {
+    const mockUpdated = {
+      id: 'rec-1',
+      catId: 'cat-1',
+      visitDate: new Date(),
+      diagnosis: '更新済み診断',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      recordedBy: 'user-1',
+      status: 'COMPLETED',
+      cat: { id: 'cat-1', name: 'Test Cat' },
+      schedule: null,
+      tags: [],
+      attachments: [],
+    };
+
+    it('should update diagnosis and replace tags/attachments', async () => {
+      mockPrismaService.medicalRecord.findUnique.mockResolvedValue({ id: 'rec-1' });
+      mockPrismaService.medicalRecord.update.mockResolvedValue(mockUpdated);
+
+      const result = await service.updateMedicalRecord('rec-1', {
+        diagnosis: '更新済み診断',
+        tagIds: ['tag-1'],
+        attachments: [{ url: 'https://example.com/a.png' }],
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data.diagnosis).toBe('更新済み診断');
+      const updateArgs = mockPrismaService.medicalRecord.update.mock.calls[0][0];
+      expect(updateArgs.data.diagnosis).toBe('更新済み診断');
+      // tags / attachments は全置換（deleteMany + create）であること
+      expect(updateArgs.data.tags).toEqual({
+        deleteMany: {},
+        create: [{ tagId: 'tag-1' }],
+      });
+      expect(updateArgs.data.attachments.deleteMany).toEqual({});
+      expect(updateArgs.data.attachments.create).toHaveLength(1);
+    });
+
+    it('should throw NotFoundException for invalid id', async () => {
+      mockPrismaService.medicalRecord.findUnique.mockResolvedValue(null);
+
+      await expect(service.updateMedicalRecord('invalid', {})).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('deleteMedicalRecord', () => {
+    it('should delete a medical record successfully', async () => {
+      mockPrismaService.medicalRecord.findUnique.mockResolvedValue({ id: 'rec-1' });
+      mockPrismaService.medicalRecord.delete.mockResolvedValue({ id: 'rec-1' });
+
+      const result = await service.deleteMedicalRecord('rec-1');
+
+      expect(result.success).toBe(true);
+      expect(mockPrismaService.medicalRecord.delete).toHaveBeenCalledWith({
+        where: { id: 'rec-1' },
+      });
+    });
+
+    it('should throw NotFoundException for invalid id', async () => {
+      mockPrismaService.medicalRecord.findUnique.mockResolvedValue(null);
+
+      await expect(service.deleteMedicalRecord('invalid')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('updateScheduleStatus', () => {
+    it('should update schedule status', async () => {
+      const mockSchedule = {
+        id: '1',
+        name: 'Vaccine',
+        title: 'Vaccine',
+        description: null,
+        scheduleDate: new Date(),
+        endDate: null,
+        timezone: null,
+        scheduleType: 'CARE',
+        status: 'CANCELLED',
+        careType: 'HEALTH_CHECK',
+        priority: 'MEDIUM',
+        recurrenceRule: null,
+        assignedTo: 'user-1',
+        cat: null,
+        scheduleCats: [],
+        reminders: [],
+        tags: [],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      mockPrismaService.schedule.findUnique.mockResolvedValue({ id: '1' });
+      mockPrismaService.schedule.update.mockResolvedValue(mockSchedule);
+
+      const result = await service.updateScheduleStatus('1', 'CANCELLED');
+
+      expect(result.success).toBe(true);
+      expect(result.data.status).toBe('CANCELLED');
+      expect(mockPrismaService.schedule.update).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: '1' }, data: { status: 'CANCELLED' } }),
+      );
+    });
+
+    it('should throw NotFoundException for invalid schedule', async () => {
+      mockPrismaService.schedule.findUnique.mockResolvedValue(null);
+
+      await expect(service.updateScheduleStatus('invalid', 'PENDING')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
 });
+

--- a/backend/src/care/care.service.spec.ts
+++ b/backend/src/care/care.service.spec.ts
@@ -1,4 +1,5 @@
 import { NotFoundException } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Test, TestingModule } from '@nestjs/testing';
 
 import { PrismaService } from '../prisma/prisma.service';
@@ -64,6 +65,10 @@ describe('CareService', () => {
         {
           provide: PrismaService,
           useValue: mockPrismaService,
+        },
+        {
+          provide: EventEmitter2,
+          useValue: { emit: jest.fn() },
         },
       ],
     }).compile();
@@ -159,6 +164,7 @@ describe('CareService', () => {
         catId: 'cat-1',
         scheduleType: 'CARE',
         careType: 'HEALTH_CHECK',
+        scheduleCats: [],
       };
 
       const mockCareRecord = {

--- a/backend/src/care/care.service.ts
+++ b/backend/src/care/care.service.ts
@@ -446,6 +446,31 @@ export class CareService {
     };
   }
 
+  /**
+   * ケアスケジュールのステータスのみを変更する（有効/無効スイッチ用）
+   */
+  async updateScheduleStatus(
+    id: string,
+    status: ScheduleStatus,
+  ): Promise<CareScheduleResponse> {
+    const existing = await this.prisma.schedule.findUnique({ where: { id } });
+
+    if (!existing) {
+      throw new NotFoundException("スケジュールが見つかりません");
+    }
+
+    const schedule = await this.prisma.schedule.update({
+      where: { id },
+      data: { status },
+      include: scheduleListInclude,
+    });
+
+    return {
+      success: true,
+      data: this.mapScheduleToResponse(schedule as ScheduleWithRelations),
+    };
+  }
+
   async deleteSchedule(id: string): Promise<{ success: true; message: string }> {
     const existing = await this.prisma.schedule.findUnique({
       where: { id },

--- a/backend/src/care/care.service.ts
+++ b/backend/src/care/care.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, NotFoundException } from "@nestjs/common";
+import { EventEmitter2 } from "@nestjs/event-emitter";
 import {
   CareType,
   MedicalRecordStatus,
@@ -10,6 +11,7 @@ import {
 } from "@prisma/client";
 
 import { PrismaService } from "../prisma/prisma.service";
+import { TAG_AUTOMATION_EVENTS } from "../tags/events/tag-automation.events";
 
 
 import {
@@ -55,6 +57,7 @@ const scheduleListInclude = {
 
 const scheduleMinimalInclude = {
   cat: { select: { id: true, name: true } },
+  scheduleCats: { select: { catId: true } },
   tags: { select: { careTagId: true } },
 } as const;
 
@@ -131,7 +134,10 @@ const toIsoString = (value?: Date | null): string | null =>
 
 @Injectable()
 export class CareService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly eventEmitter: EventEmitter2,
+  ) {}
 
   async findSchedules(query: CareQueryDto): Promise<CareScheduleListResponse> {
     const { page = 1, limit = 20, catId, careType, dateFrom, dateTo } = query;
@@ -291,6 +297,25 @@ export class CareService {
       }
 
       return { updated, careRecord, medicalRecordId };
+    });
+
+    // PAGE_ACTION（care.complete）タイプのタグ自動化ルール向けイベントを対象猫ごとに発火
+    const completedCatIds = new Set<string>();
+    if (existing.catId) {
+      completedCatIds.add(existing.catId);
+    }
+    for (const scheduleCat of existing.scheduleCats) {
+      completedCatIds.add(scheduleCat.catId);
+    }
+    completedCatIds.forEach((catId) => {
+      this.eventEmitter.emit(TAG_AUTOMATION_EVENTS.PAGE_ACTION, {
+        eventType: "PAGE_ACTION" as const,
+        timestamp: new Date(),
+        page: "care",
+        action: "complete",
+        targetId: catId,
+        targetType: "cat",
+      });
     });
 
     return {

--- a/backend/src/care/care.service.ts
+++ b/backend/src/care/care.service.ts
@@ -18,6 +18,7 @@ import {
   CreateCareScheduleDto,
   CreateMedicalRecordDto,
   MedicalRecordQueryDto,
+  UpdateMedicalRecordDto,
 } from "./dto";
 import type {
   CareScheduleListResponse,
@@ -449,6 +450,120 @@ export class CareService {
     return {
       success: true,
       data: this.mapMedicalRecordToResponse(record),
+    };
+  }
+
+  async findMedicalRecordById(id: string): Promise<MedicalRecordResponse> {
+    const record = await this.prisma.medicalRecord.findUnique({
+      where: { id },
+      include: medicalRecordInclude,
+    });
+
+    if (!record) {
+      throw new NotFoundException("医療記録が見つかりません");
+    }
+
+    return {
+      success: true,
+      data: this.mapMedicalRecordToResponse(record),
+    };
+  }
+
+  async updateMedicalRecord(
+    id: string,
+    dto: UpdateMedicalRecordDto,
+  ): Promise<MedicalRecordResponse> {
+    const existing = await this.prisma.medicalRecord.findUnique({ where: { id } });
+
+    if (!existing) {
+      throw new NotFoundException("医療記録が見つかりません");
+    }
+
+    const data: Prisma.MedicalRecordUpdateInput = {};
+
+    if (dto.catId !== undefined) {
+      data.cat = { connect: { id: dto.catId } };
+    }
+    if (dto.scheduleId !== undefined) {
+      data.schedule = dto.scheduleId ? { connect: { id: dto.scheduleId } } : { disconnect: true };
+    }
+    if (dto.visitDate !== undefined) {
+      data.visitDate = new Date(dto.visitDate);
+    }
+    if (dto.visitTypeId !== undefined) {
+      data.visitType = dto.visitTypeId ? { connect: { id: dto.visitTypeId } } : { disconnect: true };
+    }
+    if (dto.hospitalName !== undefined) {
+      data.hospitalName = this.normalizeOptionalText(dto.hospitalName) ?? null;
+    }
+    if (dto.symptom !== undefined) {
+      data.symptom = dto.symptom;
+    }
+    if (dto.symptomDetails !== undefined) {
+      data.symptomDetails = serializeSymptomDetails(mapDtoToSymptomDetails(dto.symptomDetails));
+    }
+    if (dto.diagnosis !== undefined) {
+      data.diagnosis = dto.diagnosis;
+    }
+    if (dto.treatmentPlan !== undefined) {
+      data.treatmentPlan = dto.treatmentPlan;
+    }
+    if (dto.medications !== undefined) {
+      data.medications = serializeMedications(mapDtoToMedications(dto.medications));
+    }
+    if (dto.followUpDate !== undefined) {
+      data.followUpDate = dto.followUpDate ? new Date(dto.followUpDate) : null;
+    }
+    if (dto.status !== undefined) {
+      data.status = dto.status;
+    }
+    if (dto.notes !== undefined) {
+      data.notes = dto.notes;
+    }
+    if (dto.tagIds !== undefined) {
+      data.tags = {
+        deleteMany: {},
+        create: dto.tagIds.map((tagId) => ({ tagId })),
+      };
+    }
+    if (dto.attachments !== undefined) {
+      data.attachments = {
+        deleteMany: {},
+        create: dto.attachments.map((attachment: MedicalRecordAttachmentInput) => ({
+          url: attachment.url,
+          description: attachment.description,
+          fileName: attachment.fileName,
+          fileType: attachment.fileType,
+          fileSize: attachment.fileSize,
+          capturedAt: attachment.capturedAt ? new Date(attachment.capturedAt) : undefined,
+        })),
+      };
+    }
+
+    const record = await this.prisma.medicalRecord.update({
+      where: { id },
+      data,
+      include: medicalRecordInclude,
+    });
+
+    return {
+      success: true,
+      data: this.mapMedicalRecordToResponse(record),
+    };
+  }
+
+  async deleteMedicalRecord(id: string): Promise<{ success: true; message: string }> {
+    const existing = await this.prisma.medicalRecord.findUnique({ where: { id } });
+
+    if (!existing) {
+      throw new NotFoundException("医療記録が見つかりません");
+    }
+
+    await this.prisma.medicalRecord.delete({ where: { id } });
+
+    return {
+      success: true,
+      message: "医療記録を削除しました",
     };
   }
 

--- a/backend/src/care/care.service.ts
+++ b/backend/src/care/care.service.ts
@@ -750,7 +750,10 @@ export class CareService {
       followUpDate: toIsoString(record.followUpDate),
       status: record.status,
       notes: record.notes ?? null,
-      cat: { id: record.cat.id, name: record.cat.name },
+      // 猫削除後はスナップショット名（catName）で表示する
+      cat: record.cat
+        ? { id: record.cat.id, name: record.cat.name }
+        : { id: null, name: record.catName ?? null },
       schedule: record.schedule
         ? { id: record.schedule.id, name: record.schedule.name }
         : null,

--- a/backend/src/care/dto/care-schedule-response.dto.ts
+++ b/backend/src/care/dto/care-schedule-response.dto.ts
@@ -26,16 +26,16 @@ class CareScheduleReminderDto {
   @ApiProperty({ enum: ReminderTimingType, example: ReminderTimingType.ABSOLUTE })
   timingType!: ReminderTimingType;
 
-  @ApiPropertyOptional({ example: "2025-08-01T09:00:00.000Z" })
+  @ApiPropertyOptional({ type: String, nullable: true, example: "2025-08-01T09:00:00.000Z" })
   remindAt!: string | null;
 
-  @ApiPropertyOptional({ example: 2 })
+  @ApiPropertyOptional({ type: Number, nullable: true, example: 2 })
   offsetValue!: number | null;
 
-  @ApiPropertyOptional({ enum: ReminderOffsetUnit, example: ReminderOffsetUnit.DAY })
+  @ApiPropertyOptional({ enum: ReminderOffsetUnit, nullable: true, example: ReminderOffsetUnit.DAY })
   offsetUnit!: ReminderOffsetUnit | null;
 
-  @ApiPropertyOptional({ enum: ReminderRelativeTo, example: ReminderRelativeTo.START_DATE })
+  @ApiPropertyOptional({ enum: ReminderRelativeTo, nullable: true, example: ReminderRelativeTo.START_DATE })
   relativeTo!: ReminderRelativeTo | null;
 
   @ApiProperty({ enum: ReminderChannel, example: ReminderChannel.IN_APP })
@@ -44,19 +44,20 @@ class CareScheduleReminderDto {
   @ApiPropertyOptional({
     enum: ReminderRepeatFrequency,
     example: ReminderRepeatFrequency.NONE,
+    nullable: true,
   })
   repeatFrequency!: ReminderRepeatFrequency | null;
 
-  @ApiPropertyOptional({ example: 1 })
+  @ApiPropertyOptional({ type: Number, nullable: true, example: 1 })
   repeatInterval!: number | null;
 
-  @ApiPropertyOptional({ example: 5 })
+  @ApiPropertyOptional({ type: Number, nullable: true, example: 5 })
   repeatCount!: number | null;
 
-  @ApiPropertyOptional({ example: "2025-12-31T00:00:00.000Z" })
+  @ApiPropertyOptional({ type: String, nullable: true, example: "2025-12-31T00:00:00.000Z" })
   repeatUntil!: string | null;
 
-  @ApiPropertyOptional({ example: "前日9時に通知" })
+  @ApiPropertyOptional({ type: String, nullable: true, example: "前日9時に通知" })
   notes!: string | null;
 
   @ApiProperty({ example: true })
@@ -76,7 +77,7 @@ class CareScheduleTagDto {
   @ApiProperty({ example: 1 })
   level!: number;
 
-  @ApiPropertyOptional({ example: "parent-tag-id" })
+  @ApiPropertyOptional({ type: String, nullable: true, example: "parent-tag-id" })
   parentId!: string | null;
 }
 
@@ -90,16 +91,17 @@ export class CareScheduleItemDto {
   @ApiProperty({ example: "年次健康診断" })
   title!: string;
 
-  @ApiProperty({ example: "毎年の定期健診" })
+  // union 型 (string | null) は Swagger が型推論できず {} になるため type を明示する
+  @ApiProperty({ type: String, nullable: true, example: "毎年の定期健診" })
   description!: string | null;
 
   @ApiProperty({ example: "2025-09-01T00:00:00.000Z" })
   scheduleDate!: string;
 
-  @ApiPropertyOptional({ example: "2025-09-01T01:00:00.000Z" })
+  @ApiPropertyOptional({ type: String, nullable: true, example: "2025-09-01T01:00:00.000Z" })
   endDate!: string | null;
 
-  @ApiPropertyOptional({ example: "Asia/Tokyo" })
+  @ApiPropertyOptional({ type: String, nullable: true, example: "Asia/Tokyo" })
   timezone!: string | null;
 
   @ApiProperty({ enum: ScheduleType, example: ScheduleType.CARE })
@@ -114,7 +116,7 @@ export class CareScheduleItemDto {
   @ApiProperty({ enum: Priority, example: Priority.MEDIUM })
   priority!: Priority;
 
-  @ApiPropertyOptional({ example: "FREQ=YEARLY;INTERVAL=1" })
+  @ApiPropertyOptional({ type: String, nullable: true, example: "FREQ=YEARLY;INTERVAL=1" })
   recurrenceRule!: string | null;
 
   @ApiProperty({ example: "f3a2c1d7-1234-5678-90ab-cdef12345678" })

--- a/backend/src/care/dto/index.ts
+++ b/backend/src/care/dto/index.ts
@@ -3,6 +3,7 @@ export * from "./care-schedule-response.dto";
 export * from "./complete-care.dto";
 export * from "./create-care-schedule.dto";
 export * from "./create-medical-record.dto";
+export * from "./update-care-status.dto";
 export * from "./update-medical-record.dto";
 export * from "./medical-record-query.dto";
 export * from "./medical-record-response.dto";

--- a/backend/src/care/dto/index.ts
+++ b/backend/src/care/dto/index.ts
@@ -3,5 +3,6 @@ export * from "./care-schedule-response.dto";
 export * from "./complete-care.dto";
 export * from "./create-care-schedule.dto";
 export * from "./create-medical-record.dto";
+export * from "./update-medical-record.dto";
 export * from "./medical-record-query.dto";
 export * from "./medical-record-response.dto";

--- a/backend/src/care/dto/medical-record-response.dto.ts
+++ b/backend/src/care/dto/medical-record-response.dto.ts
@@ -222,7 +222,8 @@ export type MedicalRecordData = {
   followUpDate: string | null;
   status: MedicalRecordStatus;
   notes: string | null;
-  cat: { id: string; name: string };
+  // 猫削除後は id: null + スナップショット名で返す
+  cat: { id: string | null; name: string | null };
   schedule: { id: string; name: string } | null;
   tags: {
     id: string;

--- a/backend/src/care/dto/update-care-status.dto.ts
+++ b/backend/src/care/dto/update-care-status.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { ScheduleStatus } from "@prisma/client";
+import { IsEnum } from "class-validator";
+
+/**
+ * ケアスケジュールのステータス変更DTO
+ *
+ * 一覧画面の有効/無効スイッチ等から、ステータスのみを変更するために使用する。
+ */
+export class UpdateCareStatusDto {
+  @ApiProperty({ enum: ScheduleStatus, example: ScheduleStatus.PENDING })
+  @IsEnum(ScheduleStatus)
+  status!: ScheduleStatus;
+}

--- a/backend/src/care/dto/update-medical-record.dto.ts
+++ b/backend/src/care/dto/update-medical-record.dto.ts
@@ -1,0 +1,10 @@
+import { PartialType } from "@nestjs/swagger";
+
+import { CreateMedicalRecordDto } from "./create-medical-record.dto";
+
+/**
+ * 医療記録更新DTO
+ *
+ * 作成DTOの全フィールドを任意指定として受け付ける部分更新用DTO。
+ */
+export class UpdateMedicalRecordDto extends PartialType(CreateMedicalRecordDto) {}

--- a/backend/src/cats/cats.controller.ts
+++ b/backend/src/cats/cats.controller.ts
@@ -152,6 +152,25 @@ export class CatsController {
     return this.catsService.findKittens(query);
   }
 
+  // NOTE: 静的パスは @Get(":id") より前に定義しないと :id に吸われて 400 になる
+  @Get("genders")
+  @ApiOperation({ summary: "性別マスタデータを取得" })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: "性別マスタデータを返却",
+  })
+  getGenders() {
+    return {
+      success: true,
+      data: GENDER_MASTER.map(record => ({
+        id: parseInt(record.key),
+        code: parseInt(record.key),
+        name: record.name,
+        canonical: record.canonical,
+      })),
+    };
+  }
+
   @Get(":id")
   @ApiOperation({ summary: "IDで猫データを取得" })
   @ApiResponse({ status: HttpStatus.OK, description: "猫データ" })
@@ -249,23 +268,6 @@ export class CatsController {
     return this.catsService.remove(id);
   }
 
-  @Get("genders")
-  @ApiOperation({ summary: "性別マスタデータを取得" })
-  @ApiResponse({
-    status: HttpStatus.OK,
-    description: "性別マスタデータを返却",
-  })
-  getGenders() {
-    return {
-      success: true,
-      data: GENDER_MASTER.map(record => ({
-        id: parseInt(record.key),
-        code: parseInt(record.key),
-        name: record.name,
-        canonical: record.canonical,
-      })),
-    };
-  }
 
   // ==========================================
   // 体重記録 API エンドポイント

--- a/backend/src/cats/cats.service.spec.ts
+++ b/backend/src/cats/cats.service.spec.ts
@@ -18,12 +18,38 @@ describe('CatsService', () => {
       findMany: jest.fn(),
       findUnique: jest.fn(),
       update: jest.fn(),
+      updateMany: jest.fn(),
       delete: jest.fn(),
       count: jest.fn(),
       groupBy: jest.fn(),
     },
     kittenDisposition: {
       deleteMany: jest.fn(),
+      updateMany: jest.fn(),
+    },
+    careRecord: {
+      deleteMany: jest.fn(),
+    },
+    galleryEntry: {
+      deleteMany: jest.fn(),
+    },
+    schedule: {
+      deleteMany: jest.fn(),
+    },
+    medicalRecord: {
+      updateMany: jest.fn(),
+    },
+    breedingRecord: {
+      updateMany: jest.fn(),
+    },
+    breedingSchedule: {
+      updateMany: jest.fn(),
+    },
+    pregnancyCheck: {
+      updateMany: jest.fn(),
+    },
+    birthPlan: {
+      updateMany: jest.fn(),
     },
     breed: {
       findUnique: jest.fn(),
@@ -40,6 +66,7 @@ describe('CatsService', () => {
     catTag: {
       count: jest.fn(),
     },
+    $transaction: jest.fn(),
   };
 
   const mockEventEmitter = {
@@ -228,11 +255,17 @@ describe('CatsService', () => {
 
       mockPrismaService.cat.findUnique.mockResolvedValue(mockCat);
       mockPrismaService.cat.delete.mockResolvedValue(mockCat);
+      mockPrismaService.$transaction.mockImplementation(
+        async (callback: (tx: typeof mockPrismaService) => Promise<unknown>) =>
+          callback(mockPrismaService),
+      );
 
       await service.remove('1');
 
-      expect(mockPrismaService.kittenDisposition.deleteMany).toHaveBeenCalledWith({
+      // 子猫処遇は削除せずリンク切断（繁殖履歴をテキストで残す方針）
+      expect(mockPrismaService.kittenDisposition.updateMany).toHaveBeenCalledWith({
         where: { kittenId: '1' },
+        data: { kittenId: null },
       });
       expect(mockPrismaService.cat.delete).toHaveBeenCalledWith({
         where: { id: '1' },

--- a/backend/src/cats/cats.service.ts
+++ b/backend/src/cats/cats.service.ts
@@ -147,6 +147,15 @@ export class CatsService {
           motherId: motherId || undefined,
           fatherId: fatherId || undefined,
         });
+
+        // PAGE_ACTION（kittens.register）ルール向けイベント
+        this.emitPageActionEvent("kittens", "register", cat.id);
+      }
+
+      if (cat) {
+        // PAGE_ACTION（cats-new.create / create_success）ルール向けイベント
+        this.emitPageActionEvent("cats-new", "create", cat.id);
+        this.emitPageActionEvent("cats-new", "create_success", cat.id);
       }
 
       return cat;
@@ -357,7 +366,7 @@ export class CatsService {
         }
       }
 
-      return await this.prisma.cat.update({
+      const updatedCat = await this.prisma.cat.update({
         where: { id },
         data: {
           ...(name ? { name } : {}),
@@ -374,6 +383,11 @@ export class CatsService {
         },
         include: catWithRelationsInclude,
       });
+
+      // PAGE_ACTION（cats-detail.update）ルール向けイベント
+      this.emitPageActionEvent("cats-detail", "update", updatedCat.id);
+
+      return updatedCat;
     } catch (error) {
       if (
         error instanceof Prisma.PrismaClientKnownRequestError &&
@@ -387,6 +401,20 @@ export class CatsService {
       }
       throw error;
     }
+  }
+
+  /**
+   * PAGE_ACTION タイプのタグ自動化ルール向けイベントを発火する
+   */
+  private emitPageActionEvent(page: string, action: string, catId: string): void {
+    this.eventEmitter.emit(TAG_AUTOMATION_EVENTS.PAGE_ACTION, {
+      eventType: "PAGE_ACTION" as const,
+      timestamp: new Date(),
+      page,
+      action,
+      targetId: catId,
+      targetType: "cat",
+    });
   }
 
   async remove(id: string) {

--- a/backend/src/cats/cats.service.ts
+++ b/backend/src/cats/cats.service.ts
@@ -417,23 +417,114 @@ export class CatsService {
     });
   }
 
+  /**
+   * 猫の削除
+   *
+   * 削除ポリシー:
+   * - 猫個体に属する記録（ケア履歴・体重・タグ・ギャラリー・単独スケジュール）は削除
+   * - 医療記録・繁殖履歴（交配記録/配種スケジュール/妊娠確認/出産予定/子猫処遇）は
+   *   レコードを残し、リンクを切断して名前をテキスト（スナップショット）で保持
+   * - 子猫の母/父参照も名前スナップショットに置き換える
+   */
   async remove(id: string) {
     const existingCat = await this.prisma.cat.findUnique({
       where: { id },
+      select: { id: true, name: true },
     });
 
     if (!existingCat) {
-      throw new NotFoundException(`Cat with ID ${id} not found`);
+      throw new NotFoundException(`猫が見つかりません（ID: ${id}）`);
     }
 
-    await this.prisma.kittenDisposition.deleteMany({
-      where: { kittenId: id },
-    });
+    const catName = existingCat.name;
 
-    return this.prisma.cat.delete({
-      where: { id },
-      include: catWithRelationsInclude,
-    });
+    try {
+      return await this.prisma.$transaction(async (tx) => {
+        // 1) 猫個体に属する記録を削除
+        //    （体重・タグ・タグ履歴・スケジュール紐付け・卒業記録はスキーマの Cascade で削除される）
+        await tx.careRecord.deleteMany({ where: { catId: id } });
+        await tx.galleryEntry.deleteMany({ where: { catId: id } });
+        // この猫だけを対象とするケアスケジュールは削除（複数猫スケジュールは残す）
+        await tx.schedule.deleteMany({
+          where: {
+            catId: id,
+            scheduleCats: { none: { catId: { not: id } } },
+          },
+        });
+
+        // 2) 医療記録: 後から参照できるようリンクを切断して名前を保持
+        await tx.medicalRecord.updateMany({
+          where: { catId: id },
+          data: { catId: null, catName },
+        });
+
+        // 3) 繁殖履歴: リンクを切断して名前を保持
+        await tx.breedingRecord.updateMany({
+          where: { maleId: id },
+          data: { maleId: null, maleName: catName },
+        });
+        await tx.breedingRecord.updateMany({
+          where: { femaleId: id },
+          data: { femaleId: null, femaleName: catName },
+        });
+        await tx.breedingSchedule.updateMany({
+          where: { maleId: id },
+          data: { maleId: null, maleName: catName },
+        });
+        await tx.breedingSchedule.updateMany({
+          where: { femaleId: id },
+          data: { femaleId: null, femaleName: catName },
+        });
+        await tx.pregnancyCheck.updateMany({
+          where: { motherId: id },
+          data: { motherId: null, motherName: catName },
+        });
+        await tx.pregnancyCheck.updateMany({
+          where: { fatherId: id },
+          data: { fatherId: null, fatherName: catName },
+        });
+        await tx.birthPlan.updateMany({
+          where: { motherId: id },
+          data: { motherId: null, motherName: catName },
+        });
+        await tx.birthPlan.updateMany({
+          where: { fatherId: id },
+          data: { fatherId: null, fatherName: catName },
+        });
+        // 子猫処遇は KittenDisposition.name に名前を保持済みのためリンク切断のみ
+        await tx.kittenDisposition.updateMany({
+          where: { kittenId: id },
+          data: { kittenId: null },
+        });
+
+        // 4) 子猫の母/父参照を名前スナップショットに置き換え
+        await tx.cat.updateMany({
+          where: { motherId: id },
+          data: { motherId: null, motherName: catName },
+        });
+        await tx.cat.updateMany({
+          where: { fatherId: id },
+          data: { fatherId: null, fatherName: catName },
+        });
+
+        // 5) 本体を削除
+        return tx.cat.delete({
+          where: { id },
+          include: catWithRelationsInclude,
+        });
+      });
+    } catch (error) {
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === "P2003"
+      ) {
+        // 想定外の参照が残っている場合のフォールバック（500 にしない）
+        throw new ConflictException(
+          "関連データが残っているため削除できません。画面を更新して再度お試しください",
+        );
+      }
+      throw error;
+    }
   }
 
   async getBreedingHistory(id: string) {

--- a/backend/src/gallery/dto/create-gallery-entry.dto.ts
+++ b/backend/src/gallery/dto/create-gallery-entry.dto.ts
@@ -8,6 +8,7 @@ import {
   IsDateString,
   IsArray,
   ValidateNested,
+  IsIn,
 } from 'class-validator';
 
 /**
@@ -66,7 +67,7 @@ export class CreateGalleryEntryDto {
     description: '性別',
     enum: ['MALE', 'FEMALE', 'NEUTER', 'SPAY'],
   })
-  @IsEnum(['MALE', 'FEMALE', 'NEUTER', 'SPAY'])
+  @IsIn(['MALE', 'FEMALE', 'NEUTER', 'SPAY'])
   gender: string;
 
   @ApiPropertyOptional({ description: '毛色' })

--- a/backend/src/graduation/dto/index.ts
+++ b/backend/src/graduation/dto/index.ts
@@ -1,1 +1,2 @@
 export * from './transfer-cat.dto';
+export * from './update-graduation.dto';

--- a/backend/src/graduation/dto/update-graduation.dto.ts
+++ b/backend/src/graduation/dto/update-graduation.dto.ts
@@ -1,0 +1,10 @@
+import { PartialType } from '@nestjs/swagger';
+
+import { TransferCatDto } from './transfer-cat.dto';
+
+/**
+ * 卒業記録更新DTO
+ *
+ * 譲渡日・譲渡先・備考を部分更新するためのDTO。
+ */
+export class UpdateGraduationDto extends PartialType(TransferCatDto) {}

--- a/backend/src/graduation/graduation.controller.ts
+++ b/backend/src/graduation/graduation.controller.ts
@@ -2,6 +2,7 @@ import {
   Controller,
   Post,
   Get,
+  Patch,
   Delete,
   Param,
   Body,
@@ -21,7 +22,7 @@ import {
 
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 
-import { TransferCatDto } from './dto';
+import { TransferCatDto, UpdateGraduationDto } from './dto';
 import { GraduationService } from './graduation.service';
 
 @ApiTags('Graduation')
@@ -72,6 +73,21 @@ export class GraduationController {
   @ApiResponse({ status: 404, description: '卒業記録が見つかりません' })
   async findOneGraduation(@Param('id') id: string) {
     return this.graduationService.findOneGraduation(id);
+  }
+
+  /**
+   * 卒業記録の更新（譲渡日・譲渡先・備考の修正）
+   */
+  @Patch(':id')
+  @ApiOperation({ summary: '卒業記録の更新' })
+  @ApiParam({ name: 'id', description: '卒業ID' })
+  @ApiResponse({ status: 200, description: '更新成功' })
+  @ApiResponse({ status: 404, description: '卒業記録が見つかりません' })
+  async updateGraduation(
+    @Param('id') id: string,
+    @Body() dto: UpdateGraduationDto,
+  ) {
+    return this.graduationService.updateGraduation(id, dto);
   }
 
   /**

--- a/backend/src/graduation/graduation.service.ts
+++ b/backend/src/graduation/graduation.service.ts
@@ -2,7 +2,7 @@ import { Injectable, NotFoundException, BadRequestException } from '@nestjs/comm
 
 import { PrismaService } from '../prisma/prisma.service';
 
-import { TransferCatDto } from './dto';
+import { TransferCatDto, UpdateGraduationDto } from './dto';
 
 @Injectable()
 export class GraduationService {
@@ -125,6 +125,38 @@ export class GraduationService {
     if (!graduation) {
       throw new NotFoundException(`Graduation with ID ${id} not found`);
     }
+
+    return {
+      success: true,
+      data: graduation,
+    };
+  }
+
+  /**
+   * 卒業記録の更新（譲渡日・譲渡先・備考の修正）
+   */
+  async updateGraduation(id: string, dto: UpdateGraduationDto) {
+    const existing = await this.prisma.graduation.findUnique({
+      where: { id },
+    });
+
+    if (!existing) {
+      throw new NotFoundException('卒業記録が見つかりません');
+    }
+
+    const graduation = await this.prisma.graduation.update({
+      where: { id },
+      data: {
+        ...(dto.transferDate !== undefined
+          ? { transferDate: new Date(dto.transferDate) }
+          : {}),
+        ...(dto.destination !== undefined ? { destination: dto.destination } : {}),
+        ...(dto.notes !== undefined ? { notes: dto.notes } : {}),
+      },
+      include: {
+        cat: true,
+      },
+    });
 
     return {
       success: true,

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -271,15 +271,22 @@ async function bootstrap() {
       res.status(health.success ? 200 : 503).json(health);
     });    // Swagger documentation
     if (process.env.NODE_ENV !== "production") {
-      const config = new DocumentBuilder()
-        .setTitle("Cat Management System API")
-        .setDescription("API for managing cat breeding and care records")
-        .setVersion("1.0")
-        .addBearerAuth()
-        .build();
+      // Swagger 生成は依存バージョン不整合で例外になり得るため、失敗してもアプリ起動は継続させる
+      try {
+        const config = new DocumentBuilder()
+          .setTitle("Cat Management System API")
+          .setDescription("API for managing cat breeding and care records")
+          .setVersion("1.0")
+          .addBearerAuth()
+          .build();
 
-      const document = SwaggerModule.createDocument(app, config);
-      SwaggerModule.setup("api/docs", app, document);
+        const document = SwaggerModule.createDocument(app, config);
+        SwaggerModule.setup("api/docs", app, document);
+      } catch (swaggerError) {
+        logger.warn(
+          `Swagger ドキュメントの生成に失敗したためスキップします（アプリは継続起動）: ${swaggerError instanceof Error ? swaggerError.message : String(swaggerError)}`,
+        );
+      }
     }
 
     if (!process.env.PORT && process.env.NODE_ENV === 'production') {
@@ -308,6 +315,9 @@ async function bootstrap() {
     logger.log(`❤️  Health Check: http://localhost:${port}/health`);
   } catch (error) {
     logger.error("Failed to start application:", error);
+    // bufferLogs + 非同期 transport では process.exit までにログが flush されず
+    // 起動失敗が無音になるため、標準エラーへ直接も出力する
+    console.error("Failed to start application:", error);
     process.exit(1);
   }
 }

--- a/backend/src/staff/staff.service.ts
+++ b/backend/src/staff/staff.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException, ConflictException } from '@nestjs/common';
 import { Staff, Prisma } from '@prisma/client';
 
 import { StaffResponseDto, StaffListResponseDto, Weekday, WorkTimeTemplate } from '../common/types/staff.types';
@@ -54,6 +54,21 @@ export class StaffService {
    * スタッフを新規作成
    */
   async create(createStaffDto: CreateStaffDto): Promise<StaffResponseDto> {
+    // メールアドレス重複（論理削除済み含む）を事前チェックし、日本語エラーで返す
+    if (createStaffDto.email) {
+      const existing = await this.prisma.staff.findFirst({
+        where: { email: createStaffDto.email },
+        select: { id: true, isActive: true },
+      });
+      if (existing) {
+        throw new ConflictException(
+          existing.isActive
+            ? '同じメールアドレスのスタッフが既に登録されています'
+            : '同じメールアドレスの削除済みスタッフが存在します。復元機能をご利用ください',
+        );
+      }
+    }
+
     const staff = await this.prisma.staff.create({
       data: {
         name: createStaffDto.name,

--- a/backend/src/staff/staff.service.ts
+++ b/backend/src/staff/staff.service.ts
@@ -69,22 +69,34 @@ export class StaffService {
       }
     }
 
-    const staff = await this.prisma.staff.create({
-      data: {
-        name: createStaffDto.name,
-        email: createStaffDto.email || null,
-        role: createStaffDto.role || 'スタッフ',
-        color: createStaffDto.color || '#4dabf7',
-        userId: createStaffDto.userId || null,
-        isActive: createStaffDto.isActive !== undefined ? createStaffDto.isActive : true,
-        workingDays: createStaffDto.workingDays 
-          ? (createStaffDto.workingDays as Prisma.InputJsonValue)
-          : Prisma.JsonNull,
-        workTimeTemplate: createStaffDto.workTimeTemplate 
-          ? (createStaffDto.workTimeTemplate as unknown as Prisma.InputJsonValue)
-          : Prisma.JsonNull,
-      },
-    });
+    let staff: Staff;
+    try {
+      staff = await this.prisma.staff.create({
+        data: {
+          name: createStaffDto.name,
+          email: createStaffDto.email || null,
+          role: createStaffDto.role || 'スタッフ',
+          color: createStaffDto.color || '#4dabf7',
+          userId: createStaffDto.userId || null,
+          isActive: createStaffDto.isActive !== undefined ? createStaffDto.isActive : true,
+          workingDays: createStaffDto.workingDays
+            ? (createStaffDto.workingDays as Prisma.InputJsonValue)
+            : Prisma.JsonNull,
+          workTimeTemplate: createStaffDto.workTimeTemplate
+            ? (createStaffDto.workTimeTemplate as unknown as Prisma.InputJsonValue)
+            : Prisma.JsonNull,
+        },
+      });
+    } catch (error) {
+      // 事前チェックをすり抜けた並行リクエスト等のユニーク制約違反も 409 に変換する
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === 'P2002'
+      ) {
+        throw new ConflictException('同じメールアドレスのスタッフが既に登録されています');
+      }
+      throw error;
+    }
 
     return this.toResponseDto(staff);
   }

--- a/backend/src/tags/age-threshold-checker.service.ts
+++ b/backend/src/tags/age-threshold-checker.service.ts
@@ -24,7 +24,7 @@ export class AgeThresholdCheckerService {
    * 毎日午前0時に年齢閾値をチェック
    */
   @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
-  async checkAgeThresholds() {
+  async checkAgeThresholds(ruleIdFilter?: string) {
     this.logger.log("年齢閾値チェック開始");
 
     try {
@@ -33,6 +33,7 @@ export class AgeThresholdCheckerService {
         where: {
           isActive: true,
           eventType: "AGE_THRESHOLD",
+          ...(ruleIdFilter ? { id: ruleIdFilter } : {}),
         },
       });
 
@@ -114,6 +115,14 @@ export class AgeThresholdCheckerService {
     const config = rule.config as Record<string, unknown> | null;
     if (!config) return false;
 
+    // UI（タグ管理ページ）が保存する形式: { ageType: 'days' | 'months', threshold: number }
+    // 閾値到達後は毎日マッチし続けるが、タグ付与/剥奪は冪等のため問題ない
+    if (typeof config.threshold === 'number') {
+      const ageType = config.ageType === 'months' ? 'months' : 'days';
+      const age = ageType === 'months' ? ageInMonths : ageInDays;
+      return age >= config.threshold;
+    }
+
     // 子猫用の日数チェック（母猫IDがある場合）
     if (motherId && config.kitten) {
       const kittenConfig = config.kitten as Record<string, unknown>;
@@ -142,10 +151,10 @@ export class AgeThresholdCheckerService {
   }
 
   /**
-   * 手動で年齢チェックを実行（テスト用）
+   * 手動で年齢チェックを実行（ルールIDを指定するとそのルールのみ評価）
    */
-  async manualCheck() {
+  async manualCheck(ruleId?: string) {
     this.logger.log("手動年齢閾値チェックを実行");
-    await this.checkAgeThresholds();
+    await this.checkAgeThresholds(ruleId);
   }
 }

--- a/backend/src/tags/events/tag-automation.events.ts
+++ b/backend/src/tags/events/tag-automation.events.ts
@@ -62,6 +62,8 @@ export interface AgeThresholdEvent extends BaseAutomationEvent {
   catId: string;
   ageInMonths: number;
   thresholdMonths: number;
+  /** 閾値に一致したルールID。指定時はそのルールのみ実行される */
+  ruleId?: string;
 }
 
 /**
@@ -75,6 +77,18 @@ export interface PageActionEvent extends BaseAutomationEvent {
   targetId: string; // 対象のリソースID（猫ID、交配記録IDなど）
   targetType?: string; // 'cat', 'breeding', 'health_record' など
   additionalData?: Record<string, unknown>; // アクション固有の追加データ
+}
+
+/**
+ * タグ付与・剥奪イベント
+ * 手動操作でタグが付与/剥奪された際に発火する
+ * （自動化による付与では無限ループ防止のため発火しない）
+ */
+export interface TagAssignedEvent extends BaseAutomationEvent {
+  eventType: 'TAG_ASSIGNED';
+  catId: string;
+  tagId: string;
+  action: 'ASSIGNED' | 'UNASSIGNED';
 }
 
 /**
@@ -97,6 +111,7 @@ export type TagAutomationEvent =
   | KittenRegisteredEvent
   | AgeThresholdEvent
   | PageActionEvent
+  | TagAssignedEvent
   | CustomEvent;
 
 /**
@@ -109,5 +124,6 @@ export const TAG_AUTOMATION_EVENTS = {
   KITTEN_REGISTERED: 'tag.automation.kitten.registered',
   AGE_THRESHOLD: 'tag.automation.age.threshold',
   PAGE_ACTION: 'tag.automation.page.action',
+  TAG_ASSIGNED: 'tag.automation.tag.assigned',
   CUSTOM: 'tag.automation.custom',
 } as const;

--- a/backend/src/tags/tag-automation-execution.service.ts
+++ b/backend/src/tags/tag-automation-execution.service.ts
@@ -9,7 +9,6 @@ import {
 import { PrismaService } from "../prisma/prisma.service";
 
 import { AgeThresholdCheckerService } from "./age-threshold-checker.service";
-
 import {
   TAG_AUTOMATION_EVENTS,
   type TagAutomationEvent,

--- a/backend/src/tags/tag-automation-execution.service.ts
+++ b/backend/src/tags/tag-automation-execution.service.ts
@@ -375,7 +375,9 @@ export class TagAutomationExecutionService {
         const tagEvent = event as TagAssignedEvent;
         const config = rule.config as Record<string, unknown> | null;
         const triggerTagId = config?.['triggerTagId'] as string | undefined;
-        if (!triggerTagId || triggerTagId === tagEvent.tagId) {
+        // トリガータグが設定され、かつ一致した場合のみ対象とする
+        // （未設定ルールが全タグ操作で発火するのを防ぐ）
+        if (triggerTagId && triggerTagId === tagEvent.tagId) {
           catIds.push(tagEvent.catId);
         }
         break;

--- a/backend/src/tags/tag-automation-execution.service.ts
+++ b/backend/src/tags/tag-automation-execution.service.ts
@@ -8,6 +8,8 @@ import {
 
 import { PrismaService } from "../prisma/prisma.service";
 
+import { AgeThresholdCheckerService } from "./age-threshold-checker.service";
+
 import {
   TAG_AUTOMATION_EVENTS,
   type TagAutomationEvent,
@@ -16,6 +18,7 @@ import {
   type PregnancyConfirmedEvent,
   type KittenRegisteredEvent,
   type AgeThresholdEvent,
+  type TagAssignedEvent,
   type PageActionEvent,
   type CustomEvent,
 } from "./events/tag-automation.events";
@@ -37,7 +40,114 @@ export class TagAutomationExecutionService {
     private readonly prisma: PrismaService,
     private readonly automationService: TagAutomationService,
     private readonly eventEmitter: EventEmitter2,
+    private readonly ageThresholdChecker: AgeThresholdCheckerService,
   ) { }
+
+  /**
+   * ルールを手動実行する（「今すぐ実行」用）
+   *
+   * イベントタイプごとに実データから対象猫を解決して適用する。
+   * 対象を特定できない場合はその旨を日本語メッセージで返す。
+   */
+  async executeRuleManually(
+    ruleId: string,
+    testPayload?: Record<string, unknown>,
+  ): Promise<{ success: boolean; message: string; results?: RuleExecutionResult[] }> {
+    const ruleResponse = await this.automationService.findRuleById(ruleId);
+    const rule = ruleResponse.data;
+    const config =
+      rule.config && typeof rule.config === 'object'
+        ? (rule.config as Record<string, unknown>)
+        : null;
+
+    switch (rule.eventType) {
+      case 'AGE_THRESHOLD': {
+        // 在舎猫全頭に対して、このルールの閾値判定→イベント発火を行う
+        await this.ageThresholdChecker.manualCheck(rule.id);
+        return {
+          success: true,
+          message: `年齢閾値チェックを実行しました（ルール: ${rule.name}）`,
+        };
+      }
+
+      case 'TAG_ASSIGNED': {
+        const triggerTagId = config?.['triggerTagId'] as string | undefined;
+        if (!triggerTagId) {
+          return {
+            success: false,
+            message: 'トリガータグが設定されていないため実行できません',
+          };
+        }
+
+        const catTags = await this.prisma.catTag.findMany({
+          where: { tagId: triggerTagId },
+          select: { catId: true },
+        });
+
+        if (catTags.length === 0) {
+          return {
+            success: true,
+            message: 'トリガータグが付与されている猫がいないため、適用対象はありませんでした',
+            results: [],
+          };
+        }
+
+        const results: RuleExecutionResult[] = [];
+        for (const { catId } of catTags) {
+          const event: TagAssignedEvent = {
+            eventType: 'TAG_ASSIGNED',
+            timestamp: new Date(),
+            catId,
+            tagId: triggerTagId,
+            action: 'ASSIGNED',
+          };
+          results.push(await this.executeRule(rule.id, event));
+        }
+
+        return {
+          success: true,
+          message: `${catTags.length}匹の猫に対してルールを適用しました`,
+          results,
+        };
+      }
+
+      case 'PAGE_ACTION': {
+        const targetSelection = config?.['targetSelection'] as string | undefined;
+        const targetId = testPayload?.['targetId'] as string | undefined;
+
+        if (!targetId && (!targetSelection || targetSelection === 'event_target')) {
+          return {
+            success: false,
+            message:
+              '対象の猫を特定できないため実行できません。実際のページ操作で自動適用されるのをお待ちいただくか、対象設定を見直してください',
+          };
+        }
+
+        const event: PageActionEvent = {
+          eventType: 'PAGE_ACTION',
+          timestamp: new Date(),
+          page: (config?.['page'] as string) ?? 'cats',
+          action: (config?.['action'] as string) ?? 'create',
+          targetId: targetId ?? '',
+          targetType: targetId ? 'cat' : undefined,
+        };
+
+        const result = await this.executeRule(rule.id, event);
+        return {
+          success: true,
+          message: `ルールを実行しました（タグ適用: ${result.tagsAssigned}件）`,
+          results: [result],
+        };
+      }
+
+      default: {
+        return {
+          success: false,
+          message: `このルール種別（${rule.eventType}）は手動実行に対応していません。実際のイベント発生時に自動適用されます`,
+        };
+      }
+    }
+  }
 
   /**
    * イベントに基づいてルールを実行
@@ -53,7 +163,13 @@ export class TagAutomationExecutionService {
         includeRuns: false,
       });
 
-      const rules = rulesResponse.data;
+      // イベントが特定ルール由来（AGE_THRESHOLD の閾値一致など）の場合、
+      // 他ルールのタグまで適用しないよう該当ルールに限定する
+      const eventRuleId =
+        event.eventType === 'AGE_THRESHOLD' ? (event as AgeThresholdEvent).ruleId : undefined;
+      const rules = eventRuleId
+        ? rulesResponse.data.filter((rule) => rule.id === eventRuleId)
+        : rulesResponse.data;
 
       if (rules.length === 0) {
         this.logger.debug(`No active rules found for event type: ${event.eventType}`);
@@ -251,6 +367,17 @@ export class TagAutomationExecutionService {
           if (pageEvent.targetType === 'cat') {
             catIds.push(pageEvent.targetId);
           }
+        }
+        break;
+      }
+
+      case 'TAG_ASSIGNED': {
+        // トリガータグ（config.triggerTagId）が一致する場合のみ、付与先の猫を対象とする
+        const tagEvent = event as TagAssignedEvent;
+        const config = rule.config as Record<string, unknown> | null;
+        const triggerTagId = config?.['triggerTagId'] as string | undefined;
+        if (!triggerTagId || triggerTagId === tagEvent.tagId) {
+          catIds.push(tagEvent.catId);
         }
         break;
       }
@@ -456,6 +583,15 @@ export class TagAutomationExecutionService {
   @OnEvent(TAG_AUTOMATION_EVENTS.PAGE_ACTION)
   async handlePageAction(event: PageActionEvent) {
     this.logger.log(`Handling PAGE_ACTION event: ${event.page}.${event.action}`);
+    await this.executeRulesForEvent(event);
+  }
+
+  /**
+   * イベントリスナー: タグ付与・剥奪
+   */
+  @OnEvent(TAG_AUTOMATION_EVENTS.TAG_ASSIGNED)
+  async handleTagAssigned(event: TagAssignedEvent) {
+    this.logger.log(`Handling TAG_ASSIGNED event: cat=${event.catId} tag=${event.tagId}`);
     await this.executeRulesForEvent(event);
   }
 

--- a/backend/src/tags/tag-automation-execution.service.ts
+++ b/backend/src/tags/tag-automation-execution.service.ts
@@ -24,7 +24,7 @@ import {
 } from "./events/tag-automation.events";
 import { TagAutomationService } from "./tag-automation.service";
 
-interface RuleExecutionResult {
+export interface RuleExecutionResult {
   ruleId: string;
   ruleName: string;
   success: boolean;

--- a/backend/src/tags/tag-automation.controller.ts
+++ b/backend/src/tags/tag-automation.controller.ts
@@ -11,7 +11,6 @@ import {
   Query,
   UseGuards,
 } from "@nestjs/common";
-import { EventEmitter2 } from "@nestjs/event-emitter";
 import {
   ApiBearerAuth,
   ApiOperation,
@@ -25,7 +24,7 @@ import { TagAutomationEventType, TagAutomationRunStatus, TagAutomationTriggerTyp
 import { JwtAuthGuard } from "../auth/jwt-auth.guard";
 
 import { CreateTagAutomationRuleDto, UpdateTagAutomationRuleDto } from "./dto";
-import { TAG_AUTOMATION_EVENTS } from "./events/tag-automation.events";
+import { TagAutomationExecutionService } from "./tag-automation-execution.service";
 import { TagAutomationService } from "./tag-automation.service";
 
 @ApiTags("Tag Automation")
@@ -35,7 +34,7 @@ import { TagAutomationService } from "./tag-automation.service";
 export class TagAutomationController {
   constructor(
     private readonly tagAutomationService: TagAutomationService,
-    private readonly eventEmitter: EventEmitter2,
+    private readonly executionService: TagAutomationExecutionService,
   ) {}
 
   @Get("rules")
@@ -177,109 +176,14 @@ export class TagAutomationController {
 
     @Post("rules/:id/execute")
   @HttpCode(HttpStatus.OK)
-  @ApiOperation({ summary: "ルールを手動実行（テスト用）" })
+  @ApiOperation({ summary: "ルールを手動実行（実データの対象猫に即時適用）" })
   @ApiParam({ name: "id", description: "ルールID" })
   @ApiResponse({
     status: HttpStatus.OK,
-    description: "ルール実行成功",
+    description: "ルール実行結果",
   })
   async executeRule(@Param("id") id: string, @Body() testPayload?: Record<string, unknown>) {
-    // ルールを取得
-    const ruleResponse = await this.tagAutomationService.findRuleById(id);
-    const rule = ruleResponse.data;
-
-    // テストイベントを発行
-    let eventName: string;
-    let eventPayload: Record<string, unknown>;
-
-    switch (rule.eventType) {
-      case "BREEDING_PLANNED":
-        eventName = TAG_AUTOMATION_EVENTS.BREEDING_PLANNED;
-        eventPayload = {
-          eventType: "BREEDING_PLANNED" as const,
-          breedingId: testPayload?.breedingId || "test-breeding-id",
-          maleId: testPayload?.maleId || "test-male-id",
-          femaleId: testPayload?.femaleId || "test-female-id",
-        };
-        break;
-
-      case "BREEDING_CONFIRMED":
-        eventName = TAG_AUTOMATION_EVENTS.BREEDING_CONFIRMED;
-        eventPayload = {
-          eventType: "BREEDING_CONFIRMED" as const,
-          breedingId: testPayload?.breedingId || "test-breeding-id",
-          maleId: testPayload?.maleId || "test-male-id",
-          femaleId: testPayload?.femaleId || "test-female-id",
-        };
-        break;
-
-      case "PREGNANCY_CONFIRMED":
-        eventName = TAG_AUTOMATION_EVENTS.PREGNANCY_CONFIRMED;
-        eventPayload = {
-          eventType: "PREGNANCY_CONFIRMED" as const,
-          pregnancyCheckId: testPayload?.pregnancyCheckId || "test-pregnancy-id",
-          femaleId: testPayload?.femaleId || "test-female-id",
-          maleId: testPayload?.maleId as string | undefined,
-        };
-        break;
-
-      case "KITTEN_REGISTERED":
-        eventName = TAG_AUTOMATION_EVENTS.KITTEN_REGISTERED;
-        eventPayload = {
-          eventType: "KITTEN_REGISTERED" as const,
-          kittenId: testPayload?.kittenId || "test-kitten-id",
-          motherId: testPayload?.motherId as string | undefined,
-          fatherId: testPayload?.fatherId as string | undefined,
-        };
-        break;
-
-      case "AGE_THRESHOLD":
-        eventName = TAG_AUTOMATION_EVENTS.AGE_THRESHOLD;
-        eventPayload = {
-          eventType: "AGE_THRESHOLD" as const,
-          catId: testPayload?.catId || "test-cat-id",
-          ageInMonths: testPayload?.ageInMonths || 12,
-        };
-        break;
-
-      case "PAGE_ACTION":
-        eventName = TAG_AUTOMATION_EVENTS.PAGE_ACTION;
-        eventPayload = {
-          eventType: "PAGE_ACTION" as const,
-          page: testPayload?.page || (typeof rule.config === 'object' && rule.config !== null && 'page' in rule.config ? rule.config['page'] as string : "cats"),
-          action: testPayload?.action || (typeof rule.config === 'object' && rule.config !== null && 'action' in rule.config ? rule.config['action'] as string : "create"),
-          targetId: testPayload?.targetId || "test-target-id",
-          targetType: testPayload?.targetType as string | undefined,
-          additionalData: testPayload?.additionalData as Record<string, unknown> | undefined,
-        };
-        break;
-
-      case "CUSTOM":
-        eventName = TAG_AUTOMATION_EVENTS.CUSTOM;
-        eventPayload = {
-          eventType: "CUSTOM" as const,
-          customEventType: testPayload?.customEventType || "test",
-          targetId: testPayload?.targetId || "test-target-id",
-          metadata: testPayload?.metadata as Record<string, unknown> | undefined,
-        };
-        break;
-
-      default:
-        return {
-          success: false,
-          message: `Unsupported event type: ${rule.eventType}`,
-        };
-    }
-
-    // イベント発行
-    this.eventEmitter.emit(eventName, eventPayload);
-
-    return {
-      success: true,
-      message: `Test event emitted for rule: ${rule.name}`,
-      eventType: rule.eventType,
-      eventName,
-      payload: eventPayload,
-    };
+    // 対象猫の解決と適用は実行サービス側で行う（Controller -> Service の層構造を維持）
+    return this.executionService.executeRuleManually(id, testPayload);
   }
 }

--- a/backend/src/tags/tags.service.ts
+++ b/backend/src/tags/tags.service.ts
@@ -146,8 +146,13 @@ export class TagsService {
     try {
       await this.prisma.catTag.create({ data: { catId, tagId } });
       created = true;
-    } catch {
-      // Unique constraint (already assigned) -> return success idempotently
+    } catch (error) {
+      // 付与済み（ユニーク制約 P2002）のみ冪等に成功扱いとし、それ以外は再throw
+      const isAlreadyAssigned =
+        error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002";
+      if (!isAlreadyAssigned) {
+        throw error;
+      }
     }
 
     // 手動付与時のみ TAG_ASSIGNED イベントを発火する

--- a/backend/src/tags/tags.service.ts
+++ b/backend/src/tags/tags.service.ts
@@ -1,9 +1,14 @@
 import { Injectable } from "@nestjs/common";
+import { EventEmitter2 } from "@nestjs/event-emitter";
 import { Prisma } from "@prisma/client";
 
 import { PrismaService } from "../prisma/prisma.service";
 
 import { CreateTagDto, UpdateTagDto } from "./dto";
+import {
+  TAG_AUTOMATION_EVENTS,
+  type TagAssignedEvent,
+} from "./events/tag-automation.events";
 import { TagCategoriesService } from "./tag-categories.service";
 
 @Injectable()
@@ -11,6 +16,7 @@ export class TagsService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly tagCategoriesService: TagCategoriesService,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   async findAll(options: { scopes?: string[]; includeInactive?: boolean } = {}) {
@@ -136,11 +142,20 @@ export class TagsService {
   }
 
   async assignToCat(catId: string, tagId: string) {
+    let created = false;
     try {
       await this.prisma.catTag.create({ data: { catId, tagId } });
+      created = true;
     } catch {
       // Unique constraint (already assigned) -> return success idempotently
     }
+
+    // 手動付与時のみ TAG_ASSIGNED イベントを発火する
+    // （自動化による付与は execution サービス側で発火しないため無限ループしない）
+    if (created) {
+      this.emitTagAssignedEvent(catId, tagId, "ASSIGNED");
+    }
+
     return { success: true };
   }
 
@@ -148,7 +163,25 @@ export class TagsService {
     await this.prisma.catTag.delete({
       where: { catId_tagId: { catId, tagId } },
     });
+
+    this.emitTagAssignedEvent(catId, tagId, "UNASSIGNED");
+
     return { success: true };
+  }
+
+  private emitTagAssignedEvent(
+    catId: string,
+    tagId: string,
+    action: TagAssignedEvent["action"],
+  ): void {
+    const event: TagAssignedEvent = {
+      eventType: "TAG_ASSIGNED",
+      timestamp: new Date(),
+      catId,
+      tagId,
+      action,
+    };
+    this.eventEmitter.emit(TAG_AUTOMATION_EVENTS.TAG_ASSIGNED, event);
   }
 
   private defaultTagInclude(): Prisma.TagInclude {

--- a/backend/src/tenant-settings/tenant-settings.controller.ts
+++ b/backend/src/tenant-settings/tenant-settings.controller.ts
@@ -52,8 +52,10 @@ export class TenantSettingsController {
   @ApiResponse({ status: 401, description: '認証が必要です' })
   @ApiResponse({ status: 404, description: 'テナントが見つかりません' })
   async getTagColorDefaults(@GetUser() user: RequestUser): Promise<TagColorDefaultsDto> {
+    // テナント未所属ユーザーには保存済み設定がないため、デフォルト値を返す
+    // （ページを開くたびに 400 が出る問題の修正。保存(PUT)は従来どおりテナント必須）
     if (!user.tenantId) {
-      throw new BadRequestException('テナント情報が不足しています');
+      return this.tenantSettingsService.getDefaultTagColorDefaults();
     }
     return this.tenantSettingsService.getTagColorDefaults(user.tenantId);
   }

--- a/backend/src/tenant-settings/tenant-settings.service.ts
+++ b/backend/src/tenant-settings/tenant-settings.service.ts
@@ -49,6 +49,13 @@ export class TenantSettingsService {
    * @param tenantId テナントID
    * @returns タグカラーデフォルト設定（設定がない場合はフロントエンドのデフォルト値を返す）
    */
+  /**
+   * 保存済み設定を持たないユーザー向けのデフォルト値を返す
+   */
+  getDefaultTagColorDefaults(): TagColorDefaultsDto {
+    return { ...FRONTEND_DEFAULTS };
+  }
+
   async getTagColorDefaults(tenantId: string): Promise<TagColorDefaultsDto> {
     // 設定とテナントを同時に取得
     const settings = await this.prisma.tenantSettings.findUnique({

--- a/docs/production-validation-report-2026-06.md
+++ b/docs/production-validation-report-2026-06.md
@@ -1,0 +1,175 @@
+# 本番運用アプリケーション全体検証レポート（2026-06-11）
+
+## 概要
+
+本番運用中の mycats-pro について、隔離環境（ローカル PostgreSQL 15 + シードデータ）でアプリケーションを実際に起動し、UIから遷移できる全ページの CRUD 操作と重点機能（タグ自動運用 / ケアスケジュール / スタッフシフト / 交配記録）を API レベル・UI レベルの両面から検証した。**本レポートは検証結果と修正候補の提示のみであり、アプリケーションコードの修正は行っていない。**
+
+### 検証方法
+
+| 項目 | 内容 |
+|---|---|
+| 環境 | リモートコンテナ内 Docker PostgreSQL 15（port 5433）+ `pnpm db:migrate` + シード投入。**本番 DB（Supabase）には一切接続していない** |
+| API 検証 | シード管理者（admin@example.com / ADMIN ロール）でログインし、全リソースの作成→取得→更新→削除を実データで一巡 |
+| UI 検証 | ヘッドレス Chrome（CDP 接続の Playwright）でログイン後、全 16 ルートを巡回しコンソールエラー・失敗 API を収集 |
+| 自動テスト | backend e2e 全 14 スイート、frontend 単体テスト 9 スイートを実行しベースライン取得 |
+| コード調査 | 不具合の原因箇所をソースまで遡って特定（ファイルパス・行番号付き） |
+
+### 結果サマリ
+
+- **全 16 ページのレンダリング自体は正常**（404・クラッシュなし）。基本的な CRUD は大半のリソースで動作する。
+- 一方で、**重大не具合 5 件・高 8 件・中 8 件**を確認。特に「タグの自動運用」は**実質的に全経路が機能していない**こと、**開発環境でバックエンドが起動不能**であることが判明した。
+- frontend 単体テスト: 27 件 全パス。backend e2e: 14 スイート中 4 スイート失敗（大半はテスト側の仕様乖離。詳細は §5）。
+
+---
+
+## 1. 重大（CRITICAL）— データ消失・機能不全・開発不能
+
+### C-1. 開発環境でバックエンドが起動不能（しかもエラーが一切出ない）
+
+- **症状**: `pnpm dev` でバックエンドが「Starting Cat Management System API...」のログを最後に**無言で死ぬ**。ポート 3004 は開かない。エラーログなし。
+- **原因（2段階）**:
+  1. `@nestjs/swagger@7.4.2` が Swagger ドキュメント生成時（`backend/src/main.ts:273-283`、`NODE_ENV !== "production"` のときのみ実行）に `pathToRegexp.parse is not a function` の TypeError を投げる。Express 5 / path-to-regexp v8 系と @nestjs/swagger 7.x の非互換（`app.module.ts:81-83` のコメントにある既知の問題系と同根）。
+  2. その例外を `main.ts:309-311` の catch が `logger.error` → `process.exit(1)` するが、`bufferLogs: true` + pino の worker transport が flush される前にプロセスが死ぬため、**エラーが標準出力に一切出ない**。
+- **影響**: 本番（`NODE_ENV=production`）は Swagger 生成をスキップするため発症しないが、**開発・検証・Swagger ドキュメント（/api/docs）が全滅**。今回の検証は dist の Swagger 部分を一時的に無効化して実施した。
+- **修正方針案**:
+  - `@nestjs/swagger` を Express 5 対応バージョン（v8 系 / NestJS 11 系列）へ更新するか、`SwaggerModule.createDocument` を try-catch で包んで失敗時は警告ログのみで起動継続にする（工数: 小〜中）。
+  - 併せて `main.ts` の catch で `process.exit` 前に `Logger.flush()` 相当（または `console.error(error)` のフォールバック）を入れ、起動失敗が必ず可視化されるようにする（工数: 小）。
+
+### C-2. タグの自動運用が実質全経路で機能していない
+
+ユーザー指摘の「タグの自動運用」を重点検証した結果、**UI から作成できるルールが動作する経路が存在しない**ことを確認した。
+
+| ルール種別（UIで作成可能） | 実挙動 | 原因 |
+|---|---|---|
+| PAGE_ACTION | **動作しない** | `tag.automation.page.action` イベントの発火箇所がバックエンド・フロントエンドのどこにも存在しない（grep で全件確認）。発火されるイベントは `cats.service.ts:144` の KITTEN_REGISTERED **1箇所のみ** |
+| AGE_THRESHOLD | **動作しない** | 毎日0時の cron（`age-threshold-checker.service.ts`）は config に `{kitten:{minDays,maxDays}, adult:{minMonths,maxMonths}}` を要求するが、UI（`frontend/src/app/tags/page.tsx:717-729`）は `{ageType,threshold,tagIds,actionType}` を保存する。**スキーマ不整合により `shouldTriggerRule` が常に false** |
+| TAG_ASSIGNED | **動作しない** | イベント発火箇所ゼロ。さらに手動実行 API（`tag-automation.controller.ts` の execute）の switch に TAG_ASSIGNED の case がなく `{"success":false,"message":"Unsupported event type"}` を **HTTP 200** で返すため、UI 上はエラーにすら見えない |
+| （UI作成不可）KITTEN_REGISTERED | ✅ 唯一動作 | 母猫付き子猫登録で発火し、子猫・母猫・父猫にタグ付与されることを実機確認（タグ3件付与・実行履歴記録 OK） |
+
+- **「今すぐ実行」ボタンも機能しない**: フロントは空ペイロードで execute を呼ぶが（`tags/page.tsx:704-712`）、コントローラはダミー値（`catId:"test-cat-id"` 等）でイベントを合成するため、実猫が対象にならず常に「Assigned 0 tags」になる（実機ログで確認）。
+- **修正方針案**（工数: 中〜大。優先度順）:
+  1. AGE_THRESHOLD: cron の `shouldTriggerRule` を UI の config 形式（`ageType`/`threshold`）に対応させる（チェッカー側の修正のみで開通。工数: 小）。
+  2. PAGE_ACTION: 猫作成/更新等の Service に `eventEmitter.emit(PAGE_ACTION, {...})` を追加（KITTEN_REGISTERED と同じパターンを横展開。工数: 中）。
+  3. TAG_ASSIGNED: `tags.service` のタグ付与処理でイベント発火 + execute switch に case 追加（工数: 小〜中）。
+  4. execute エンドポイントは「ルールの対象猫を実データから解決して即時適用」する仕様に変更（テストイベント合成をやめる。工数: 中）。
+
+### C-3. 関連データを持つ猫の削除が 500 エラー（既存データの削除が不可）
+
+- **症状**: ケア履歴・医療記録等を持つ猫を `DELETE /api/v1/cats/:id` すると **500 Internal Server Error**（日本語メッセージなし）。実機で再現確認済み（`Foreign key constraint violated: care_records_cat_id_fkey`）。
+- **原因**: `cats.service.ts:392-409` の `remove()` は kittenDisposition しか事前削除せず、Prisma スキーマの Cat 関連（CareRecord / MedicalRecord / BreedingRecord / PregnancyCheck / BirthPlan / motherId・fatherId 参照等）は大半が `onDelete` 未指定（= Restrict）のため FK violation で落ちる。P2003 のハンドリングもない。
+- **影響**: **一度でもケア完了・医療記録登録・交配記録を持った猫は UI から削除できない**。運用上「既存データの削除が間違いなくできるか」という要件に対する最大の障害。
+- **修正方針案**: 削除ポリシーを決めた上で、(a) 関連データをトランザクション内でカスケード削除（または論理削除へ転換）、(b) 残す場合は P2003 を捕捉して「ケア履歴があるため削除できません。先に〜」という日本語 `BadRequestException` を返す（工数: 中。論理削除化なら大）。
+
+### C-4. 配種スケジュールが DB に保存されない（交配記録ページ）
+
+- **症状**: 交配管理ページで作成した配種スケジュールはサーバーに送信されず、`GET /breeding/schedules` は常に空。localStorage 保存のみのため、**別端末・別ブラウザ・キャッシュクリアで消失し、複数ユーザー間でも共有されない**（同一ブラウザのリロードでは localStorage により残るため気づきにくい）。
+- **原因**: バックエンドには `BreedingSchedule` モデルと `/api/v1/breeding/schedules` の CRUD API が**完備**されており、フロントにも API フック（`use-breeding.ts:783-`）と同期関数（`useBreedingSchedule.ts:302-348` の `createScheduleOnServer` 等）が**実装済み**。しかし `breeding/page.tsx` がこれらを**一切呼んでいない**（`setBreedingSchedule` でローカル更新のみ。`page.tsx:514` 付近）。サーバー→ローカルの読込側（`useBreedingSchedule.ts:190-217`）は配線済みなので、書き込み側の配線漏れ。
+- **修正方針案**: `page.tsx` のスケジュール登録/成功・失敗確定/削除ハンドラから `createScheduleOnServer` / `updateScheduleOnServer` / `deleteScheduleOnServer` を呼ぶだけで開通する。**新規 API・スキーマ変更は不要**（工数: 小〜中）。
+
+### C-5. 医療記録の詳細取得・更新・削除 API が未実装（既存データの修正・削除が不可）
+
+- **症状**: `GET/PATCH/DELETE /api/v1/care/medical-records/:id` がいずれも 404（実機確認済み）。一覧と作成のみ存在（`care.controller.ts`）。
+- **影響**: 医療データページで既存記録の修正・削除が構造的に不可能。
+- **修正方針案**: Prisma モデル（MedicalRecord + 添付・タグの Cascade 設定済み）はあるため、Controller/Service に 3 エンドポイントを追加し、フロント `use-care.ts` に update/delete フックを追加（工数: 小〜中）。
+
+---
+
+## 2. 高（HIGH）— 運用上の明確な制約
+
+### H-1. 出産詳細登録ハンドラが空実装
+`frontend/src/app/breeding/page.tsx:946-948` の `onDetailSubmit` が `// 詳細登録ハンドラー（実装中）` のまま空。出産記録モーダルの詳細登録ボタンは押しても何も起きない。
+**修正案**: 簡易登録 `handleBirthInfoSubmit` と同様に `useUpdateBirthPlan` / `useCreateCat`（子猫詳細付き）を呼ぶ実装を追加（工数: 中）。
+
+### H-2. NGペアルールがバックエンドで強制されない
+ルールの定義 CRUD は動作するが、交配記録・配種スケジュール作成時の照合ロジックが `breeding.service.ts` に存在しない（NG ペアで `POST /breeding` しても素通し）。フロントは `window.confirm` の警告のみで**強行可能**（`breeding/page.tsx:460-471`）。
+**修正案**: `create`/`createBreedingSchedule` 内で NG ルール（TAG_COMBINATION / INDIVIDUAL_PROHIBITION / GENERATION_LIMIT）を照合し、違反時は日本語 `BadRequestException`。強行を許す運用なら `force` フラグを設ける（工数: 中）。
+
+### H-3. ケアスケジュールのステータス切替 Switch が disabled 固定
+`care/page.tsx:702-708`。有効/無効の表示だけで変更不可。バックエンドの `PATCH /care/schedules/:id` は status 変更を受け付けるため、フロントの配線のみで解決（工数: 小）。
+
+### H-4. 卒業記録（Graduation）の更新 API がない
+`PATCH /graduations/:id` は 404（実機確認）。卒業日・譲渡先の入力ミスは削除→再作成しか手段がない。**修正案**: PATCH エンドポイント追加（工数: 小）。
+
+### H-5. ADMIN ロールでユーザー設定ページが全面 403
+`GET /tenants` は SUPER_ADMIN 専用、`GET /users` は SUPER_ADMIN / TENANT_ADMIN 専用（RoleGuard ログで確認）。シードで作られる管理者は **ADMIN** ロールのため、`/tenants`（ユーザー設定）ページの API が全て 403 になる。ロール体系（ADMIN と TENANT_ADMIN の関係）の設計矛盾。
+**修正案**: ロール要件の見直し（ADMIN を許可するか、シード/運用ユーザーを TENANT_ADMIN にする）+ フロントでの権限不足時の日本語案内（工数: 小〜中）。
+
+### H-6. テナント未所属ユーザーでタグ管理ページが常時 400 を出す
+`GET /tenant-settings/tag-color-defaults` は `user.tenantId` が null だと「テナント情報が不足しています」の 400（`tenant-settings.controller.ts:54-56`）。シード管理者は tenantId=null のため、/tags ページを開くたびに 400 が発生し、タグ色デフォルト設定も保存不可。
+**修正案**: tenantId 未設定時はデフォルト値を 200 で返す、またはユーザーへのテナント割当を必須化（工数: 小）。
+
+### H-7. error.tsx / global-error.tsx が一つも存在しない
+`frontend/src/app` 配下に error boundary が 0 件（find で確認）。レンダリングエラー時は Next.js の素のエラー画面になる。loading.tsx も 16 ルート中 9 のみ（export / import / print-templates / tenants / more / staff/shifts 等が欠如）。
+**修正案**: ルートに `global-error.tsx` + 主要セグメントに日本語の `error.tsx` を配置（工数: 小）。
+
+### H-8. 論理削除済みスタッフと同じメールアドレスで再登録すると 500
+`POST /staff` で email 重複（論理削除済み含む）時に Prisma P2002 が未ハンドリングで 500（実機確認）。「退職→再雇用」で詰まる。
+**修正案**: P2002 捕捉で日本語 409/400 を返し、論理削除済みなら復元を案内（工数: 小）。
+
+---
+
+## 3. 中（MEDIUM）
+
+| # | 内容 | 根拠 / 修正案 |
+|---|---|---|
+| M-1 | `GET /cats/genders` がルート定義順の問題で常に 400（`@Get("genders")` が `@Get(":id")` より後: `cats.controller.ts:155/252`）。フロントは `/master/genders` を使うため実害は顕在化していないがデッドルート | `genders` を `:id` より前へ移動 or 削除 |
+| M-2 | `pnpm test:e2e` をローカルで実行すると、`.env.test` は testdb を指すのに Prisma が `backend/.env` の `DIRECT_URL`（開発DB）を拾い、**開発DBが `migrate reset` の対象になる**（CI では DIRECT_URL を上書きしているため顕在化しない） | `.env.test` に DIRECT_URL を明記する |
+| M-3 | ShiftTemplate / ShiftTask は Prisma モデルだけ存在し API ゼロ（デッドモデル）。シフトのテンプレート入力は実際には Staff.workTimeTemplate / workingDays で実現されており動作する | モデル削除 or 将来仕様の明確化 |
+| M-4 | 品種マスタに `code:0, name:""` の空レコードがあり（`breed-master.data.ts:13`）、品種選択肢の先頭に空項目が出る。猫詳細のレスポンスでも `breed.name=""` になる | マスタから除外 or UI でフィルタ |
+| M-5 | ギャラリー作成 DTO の `@IsEnum(['MALE',...])` は配列を渡す誤用（`create-gallery-entry.dto.ts:69`）で、バリデーションエラーが「gender must be one of the following values: 」と**空のまま**返る | `@IsIn([...])` に変更 |
+| M-6 | UI「今すぐ実行」失敗時も HTTP 200 のため通知が成功扱いになり得る（C-2 と同根） | C-2 の修正に含める |
+| M-7 | /cats ページでコンソール警告 `Unsupported style property &::-webkit-scrollbar`（インラインスタイルへの擬似要素指定。プロジェクト規約のインラインスタイル禁止にも抵触） | Mantine styles API / CSS Modules へ移行 |
+| M-8 | タグ自動化ルールの priority フィールドは保存されるが実行順制御に未使用 | 仕様確定後に対応（低優先） |
+
+---
+
+## 4. 動作確認済み（正常）
+
+以下は追加→一覧→（詳細）→更新→削除の一巡を実データで確認し、問題なし:
+
+- **猫**: CRUD ＋ タブ統計（/cats/statistics）＋ 子猫一覧（/cats/kittens）
+- **体重記録**: CRUD（個別・取得・更新・削除）
+- **ケアスケジュール**: CRUD ＋ 完了処理 ＋ **RRULE（FREQ=MONTHLY）完了時の次回スケジュール自動生成**（完了後に PENDING の新スケジュールが生成されることを確認）
+- **医療記録**: 作成・一覧（更新・削除は C-5 のとおり API 自体がない）
+- **タグ**: カテゴリ→グループ→タグの3階層 CRUD、猫への付与/剥奪、付与中タグの削除時も猫側は正しくクリーンアップ（Cascade 動作確認）
+- **タグ自動化**: KITTEN_REGISTERED 経路のみ実動作（子猫・母猫・父猫へ自動付与、実行履歴記録）
+- **スタッフ**: CRUD ＋ 論理削除/復元、シフト: CRUD ＋ カレンダー取得（startDate/endDate）
+- **交配記録**: 配種スケジュール API・配種チェック・妊娠確認・出産予定・子猫処遇の各 CRUD、出産完了処理、**出産予定の削除保護**（子猫処遇が残っている場合は日本語エラーで正しく拒否）
+- **血統書**: CRUD（作成・更新・削除）
+- **エクスポート**: `POST /export {dataType, format}` で CSV 本文が正しく返る
+- **認証**: ログイン / トークンリフレッシュ / 保護エンドポイントの 401
+- **UI**: 全 16 ルートのレンダリング（ログイン後巡回、クラッシュ・404 なし）
+- **frontend 単体テスト**: 9 スイート 27 件 全パス
+
+---
+
+## 5. 自動テスト基盤の課題（backend e2e: 4/14 スイート失敗）
+
+| スイート | 失敗 | 原因分類 |
+|---|---|---|
+| pedigree.e2e-spec.ts | 9/10 | **テストが未認証アクセスで 200 を期待**しており現行の JWT 必須仕様と乖離（製品バグではなくテスト未整備） |
+| export.e2e-spec.ts | 5/7 | テストは 200 + `Content-Disposition: attachment` を期待、実装は 201 + ヘッダなしで CSV 本文を返す（機能自体は動作。どちらに合わせるか要決定） |
+| auth-jwt.e2e-spec.ts | 2/17 | Helmet / CORS ヘッダは `main.ts` でのみ設定されるため、TestingModule 起動のテストでは付与されない（テスト構成の問題） |
+| auth-seed-user.e2e-spec.ts | 1〜2/3 | シード投入前提のテスト。シード後も CSRF 関連 1 件が不安定 |
+
+加えてカバレッジ欠落: 交配スケジュール/配種チェック・子猫処遇・シフト・タグ自動化・AGE_THRESHOLD cron に e2e テストが存在しない。
+
+---
+
+## 6. 修正ロードマップ（推奨順）
+
+1. **C-1 起動不能の解消 + エラー可視化**（他の全修正の前提。開発環境が直らないと検証もできない）
+2. **C-3 猫削除の 500**（データ運用の根幹。削除ポリシー決定が必要）
+3. **C-5 医療記録 update/delete API 追加** ＋ H-4 卒業 PATCH（小工数で「既存データの修正・削除」要件を回復）
+4. **C-4 配種スケジュールのサーバー同期配線** ＋ H-1 出産詳細登録（交配ページの機能完成）
+5. **C-2 タグ自動運用の開通**（まず AGE_THRESHOLD の config 不整合解消 → PAGE_ACTION / TAG_ASSIGNED のイベント発火実装）
+6. **H-2 NGルールのバックエンド強制**、H-3 ケア Switch、H-5/H-6 ロール・テナント設計の整理
+7. H-7 error.tsx / loading.tsx、H-8 ほか M 項目、e2e テストの仕様追従と未カバー領域の追加
+
+---
+
+## 付記
+
+- 検証中に作成したデータはすべてローカル検証 DB 内のみ。本番環境・本番 DB への変更は一切ない。
+- 検証環境の制約: Swagger 起動不能の回避（dist の一時パッチ、未コミット）、Playwright ブラウザは CDN 遮断のため CDP 接続のヘッドレス Chrome を使用。
+- `lodash@4.18.1` が依存に含まれる。4.17.21 以降の新系列のため、念のためサプライチェーン観点でリリース元の確認を推奨（未検証・参考情報）。

--- a/frontend/src/app/breeding/hooks/useBreedingSchedule.ts
+++ b/frontend/src/app/breeding/hooks/useBreedingSchedule.ts
@@ -52,7 +52,7 @@ export interface UseBreedingScheduleReturn {
   clearScheduleData: () => void;
   
   // API 同期関数
-  createScheduleOnServer: (entry: BreedingScheduleEntry) => Promise<void>;
+  createScheduleOnServer: (entry: BreedingScheduleEntry, options?: { force?: boolean }) => Promise<void>;
   updateScheduleOnServer: (scheduleId: string, updates: UpdateBreedingScheduleRequest) => Promise<void>;
   deleteScheduleOnServer: (scheduleId: string) => Promise<void>;
   syncFromServer: () => Promise<void>;
@@ -300,13 +300,14 @@ export function useBreedingSchedule(): UseBreedingScheduleReturn {
   }, []);
 
   // サーバーにスケジュールを作成
-  const createScheduleOnServer = useCallback(async (entry: BreedingScheduleEntry) => {
+  const createScheduleOnServer = useCallback(async (entry: BreedingScheduleEntry, options?: { force?: boolean }) => {
     const payload: CreateBreedingScheduleRequest = {
       maleId: entry.maleId,
       femaleId: entry.femaleId,
       startDate: entry.date,
       duration: entry.duration,
       status: 'SCHEDULED',
+      ...(options?.force ? { force: true } : {}),
     };
     
     try {

--- a/frontend/src/app/breeding/hooks/useBreedingSchedule.ts
+++ b/frontend/src/app/breeding/hooks/useBreedingSchedule.ts
@@ -71,7 +71,8 @@ function convertServerScheduleToLocal(
     const currentDate = new Date(startDate);
     currentDate.setDate(startDate.getDate() + i);
     const dateStr = currentDate.toISOString().split('T')[0];
-    const scheduleKey = `${schedule.maleId}-${dateStr}`;
+    // 猫削除後（maleId=null）はサーバーIDをキーに使い、削除済み同士の衝突を防ぐ
+    const scheduleKey = `${schedule.maleId ?? `deleted-${schedule.id}`}-${dateStr}`;
     
     result[scheduleKey] = {
       maleId: schedule.maleId ?? '',

--- a/frontend/src/app/breeding/hooks/useBreedingSchedule.ts
+++ b/frontend/src/app/breeding/hooks/useBreedingSchedule.ts
@@ -74,10 +74,11 @@ function convertServerScheduleToLocal(
     const scheduleKey = `${schedule.maleId}-${dateStr}`;
     
     result[scheduleKey] = {
-      maleId: schedule.maleId,
-      maleName: schedule.male?.name ?? '',
-      femaleId: schedule.femaleId,
-      femaleName: schedule.female?.name ?? '',
+      maleId: schedule.maleId ?? '',
+      // 猫が削除済みの場合はスナップショット名（テキスト）で表示する
+      maleName: schedule.male?.name ?? schedule.maleName ?? '',
+      femaleId: schedule.femaleId ?? '',
+      femaleName: schedule.female?.name ?? schedule.femaleName ?? '',
       date: dateStr,
       duration: schedule.duration,
       dayIndex: i,
@@ -104,7 +105,7 @@ function convertServerChecksToLocal(
     
     for (const check of schedule.checks) {
       const checkDate = new Date(check.checkDate).toISOString().split('T')[0];
-      const key = `${schedule.maleId}-${schedule.femaleId}-${checkDate}`;
+      const key = `${schedule.maleId ?? ''}-${schedule.femaleId ?? ''}-${checkDate}`;
       result[key] = (result[key] || 0) + check.count;
     }
   }

--- a/frontend/src/app/breeding/page.tsx
+++ b/frontend/src/app/breeding/page.tsx
@@ -87,6 +87,9 @@ export default function BreedingPage() {
     getMatingCheckCount,
     addMatingCheck,
     clearScheduleData,
+    createScheduleOnServer,
+    updateScheduleOnServer,
+    deleteScheduleOnServer,
   } = useBreedingSchedule();
 
   const [activeTab, setActiveTab] = useState('schedule');
@@ -257,10 +260,30 @@ export default function BreedingPage() {
     }
   };
 
+  // 対象ペアのサーバー側スケジュールに交配結果ステータスを反映する
+  const syncMatingResultToServer = (maleId: string, femaleName: string, result: 'success' | 'failure') => {
+    const serverIds = new Set<string>();
+    Object.keys(breedingSchedule).forEach((key) => {
+      const entry = breedingSchedule[key];
+      if (key.includes(maleId) && entry.femaleName === femaleName && !entry.isHistory && entry.serverId) {
+        serverIds.add(entry.serverId);
+      }
+    });
+    serverIds.forEach((serverId) => {
+      updateScheduleOnServer(serverId, {
+        status: result === 'success' ? 'COMPLETED' : 'CANCELLED',
+      }).catch(() => {
+        // エラー通知はミューテーション側で表示済み
+      });
+    });
+  };
+
   // 交配結果処理
   const handleMatingResult = (maleId: string, femaleId: string, femaleName: string, matingDate: string, result: 'success' | 'failure') => {
     const male = activeMales.find((m: Cat) => m.id === maleId);
-    
+
+    syncMatingResultToServer(maleId, femaleName, result);
+
     if (result === 'success') {
       const checkDate = new Date();
       checkDate.setDate(checkDate.getDate() + 21);
@@ -375,6 +398,17 @@ export default function BreedingPage() {
       return { ...updated, ...newSchedule };
     });
 
+    // サーバー側スケジュールにも期間・メス猫変更を反映
+    if (selectedScheduleForEdit.serverId) {
+      updateScheduleOnServer(selectedScheduleForEdit.serverId, {
+        femaleId: finalFemaleId,
+        startDate: startDate.toISOString().split('T')[0],
+        duration: newDuration,
+      }).catch(() => {
+        // エラー通知はミューテーション側で表示済み
+      });
+    }
+
     const message = newFemaleId && newFemaleId !== femaleId
       ? `交配期間を${newDuration}日間に変更し、メス猫を${newFemaleName}に変更しました`
       : `交配期間を${newDuration}日間に変更しました`;
@@ -405,9 +439,16 @@ export default function BreedingPage() {
         const scheduleKey = `${maleId}-${dateStr}`;
         delete updated[scheduleKey];
       }
-      
+
       return updated;
     });
+
+    // サーバー側スケジュールも削除
+    if (selectedScheduleForEdit.serverId) {
+      deleteScheduleOnServer(selectedScheduleForEdit.serverId).catch(() => {
+        // エラー通知はミューテーション側で表示済み
+      });
+    }
 
     notifications.show({
       title: '削除成功',
@@ -497,6 +538,15 @@ export default function BreedingPage() {
             isHistory: true,
             result: success ? '成功' : '失敗',
           };
+
+          // 前回ペアの結果をサーバーにも反映（成功: COMPLETED / 失敗: CANCELLED）
+          if (existingPair.serverId) {
+            updateScheduleOnServer(existingPair.serverId, {
+              status: success ? 'COMPLETED' : 'CANCELLED',
+            }).catch(() => {
+              // エラー通知はミューテーション側で表示済み
+            });
+          }
         } else if (!existingPair) {
           newSchedules[scheduleKey] = {
             maleId: selectedMale,
@@ -510,10 +560,24 @@ export default function BreedingPage() {
           };
         }
       });
-      
+
       setBreedingSchedule(prev => ({ ...prev, ...newSchedules }));
+
+      // 新規スケジュールをサーバーに永続化（期間全体を1レコードとして登録）
+      const createdEntries = Object.values(newSchedules).filter((entry) => !entry.isHistory);
+      if (createdEntries.length > 0) {
+        const firstEntry = createdEntries.reduce((a, b) => (a.dayIndex <= b.dayIndex ? a : b));
+        const scheduleStart = new Date(firstEntry.date);
+        scheduleStart.setDate(scheduleStart.getDate() - firstEntry.dayIndex);
+        createScheduleOnServer({
+          ...firstEntry,
+          date: scheduleStart.toISOString().split('T')[0],
+        }).catch(() => {
+          // エラー通知はミューテーション側で表示済み
+        });
+      }
     }
-    
+
     closeModal();
   };
 
@@ -563,9 +627,9 @@ export default function BreedingPage() {
   };
 
   // 出産情報登録
-  const handleBirthInfoSubmit = async () => {
-    if (!selectedBirthPlan) return;
-    
+  const handleBirthInfoSubmit = async (): Promise<boolean> => {
+    if (!selectedBirthPlan) return false;
+
     try {
       const birthDateStr = birthDate;
       const aliveCount = birthCount - deathCount;
@@ -613,12 +677,27 @@ export default function BreedingPage() {
       setBirthCount(0);
       setDeathCount(0);
       setBirthDate(new Date().toISOString().split('T')[0]);
+      return true;
     } catch (error) {
       notifications.show({
         title: 'エラー',
         message: error instanceof Error ? error.message : '出産情報の登録に失敗しました',
         color: 'red',
       });
+      return false;
+    }
+  };
+
+  // 詳細登録: 出産情報を登録した上で、子猫管理モーダルを開いて名前・性別等の詳細を編集できるようにする
+  const handleBirthInfoDetailSubmit = async () => {
+    if (!selectedBirthPlan) return;
+
+    const motherId = selectedBirthPlan.motherId;
+    const succeeded = await handleBirthInfoSubmit();
+
+    if (succeeded) {
+      setSelectedMotherIdForModal(motherId);
+      openManagementModal();
     }
   };
 
@@ -942,10 +1021,12 @@ export default function BreedingPage() {
         onBirthCountChange={setBirthCount}
         onDeathCountChange={setDeathCount}
         onBirthDateChange={setBirthDate}
-        onSubmit={handleBirthInfoSubmit}
+        onSubmit={() => {
+          void handleBirthInfoSubmit();
+        }}
         onDetailSubmit={() => {
-                // 詳細登録ハンドラー（実装中）
-              }}
+          void handleBirthInfoDetailSubmit();
+        }}
         isLoading={updateBirthPlanMutation.isPending || createCatMutation.isPending}
       />
 

--- a/frontend/src/app/breeding/page.tsx
+++ b/frontend/src/app/breeding/page.tsx
@@ -265,7 +265,7 @@ export default function BreedingPage() {
     const serverIds = new Set<string>();
     Object.keys(breedingSchedule).forEach((key) => {
       const entry = breedingSchedule[key];
-      if (key.includes(maleId) && entry.femaleName === femaleName && !entry.isHistory && entry.serverId) {
+      if (key.startsWith(`${maleId}-`) && entry.femaleName === femaleName && !entry.isHistory && entry.serverId) {
         serverIds.add(entry.serverId);
       }
     });
@@ -302,7 +302,7 @@ export default function BreedingPage() {
           setBreedingSchedule((prev: Record<string, BreedingScheduleEntry>) => {
             const newSchedule = { ...prev };
             Object.keys(newSchedule).forEach(key => {
-              if (key.includes(maleId) && newSchedule[key].femaleName === femaleName && !newSchedule[key].isHistory) {
+              if (key.startsWith(`${maleId}-`) && newSchedule[key].femaleName === femaleName && !newSchedule[key].isHistory) {
                 newSchedule[key] = {
                   ...newSchedule[key],
                   isHistory: true,
@@ -333,7 +333,7 @@ export default function BreedingPage() {
       setBreedingSchedule((prev: Record<string, BreedingScheduleEntry>) => {
         const newSchedule = { ...prev };
         Object.keys(newSchedule).forEach(key => {
-          if (key.includes(maleId) && newSchedule[key].femaleName === femaleName && !newSchedule[key].isHistory) {
+          if (key.startsWith(`${maleId}-`) && newSchedule[key].femaleName === femaleName && !newSchedule[key].isHistory) {
             newSchedule[key] = {
               ...newSchedule[key],
               isHistory: true,

--- a/frontend/src/app/breeding/page.tsx
+++ b/frontend/src/app/breeding/page.tsx
@@ -498,7 +498,8 @@ export default function BreedingPage() {
         }
       }
       
-      // NGペアチェック
+      // NGペアチェック（強行時はサーバーにも force を渡す）
+      let forceNgOverride = false;
       if (isNGPairing(selectedMale, femaleId)) {
         const ngRule = findMatchingRule(selectedMale, femaleId);
         
@@ -510,6 +511,7 @@ export default function BreedingPage() {
           closeModal();
           return;
         }
+        forceNgOverride = true;
       }
       
       // 各日付にスケジュールを追加
@@ -569,10 +571,13 @@ export default function BreedingPage() {
         const firstEntry = createdEntries.reduce((a, b) => (a.dayIndex <= b.dayIndex ? a : b));
         const scheduleStart = new Date(firstEntry.date);
         scheduleStart.setDate(scheduleStart.getDate() - firstEntry.dayIndex);
-        createScheduleOnServer({
-          ...firstEntry,
-          date: scheduleStart.toISOString().split('T')[0],
-        }).catch(() => {
+        createScheduleOnServer(
+          {
+            ...firstEntry,
+            date: scheduleStart.toISOString().split('T')[0],
+          },
+          { force: forceNgOverride },
+        ).catch(() => {
           // エラー通知はミューテーション側で表示済み
         });
       }

--- a/frontend/src/app/care/page.tsx
+++ b/frontend/src/app/care/page.tsx
@@ -38,6 +38,7 @@ import {
   type GetCareSchedulesParams,
   useAddCareSchedule,
   useUpdateCareSchedule,
+  useUpdateCareScheduleStatus,
   useDeleteCareSchedule,
   useCompleteCareSchedule,
   useGetCareSchedules,
@@ -210,6 +211,7 @@ export default function CarePage() {
   const scheduleQuery = useGetCareSchedules(scheduleParams);
   const addScheduleMutation = useAddCareSchedule();
   const updateScheduleMutation = useUpdateCareSchedule();
+  const updateStatusMutation = useUpdateCareScheduleStatus();
   const deleteScheduleMutation = useDeleteCareSchedule();
   const completeScheduleMutation = useCompleteCareSchedule();
 
@@ -704,7 +706,13 @@ export default function CarePage() {
                               size="sm"
                               onLabel="有効"
                               offLabel="無効"
-                              disabled
+                              disabled={schedule.status === 'COMPLETED' || updateStatusMutation.isPending}
+                              onChange={(event) => {
+                                updateStatusMutation.mutate({
+                                  id: schedule.id,
+                                  status: event.currentTarget.checked ? 'PENDING' : 'CANCELLED',
+                                });
+                              }}
                             />
                           </Table.Td>
                           <Table.Td>

--- a/frontend/src/lib/api/generated/schema.ts
+++ b/frontend/src/lib/api/generated/schema.ts
@@ -159,6 +159,246 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/users": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * ユーザー一覧取得
+         * @description SUPER_ADMINは全ユーザー、TENANT_ADMINは自テナントのユーザーを取得します。
+         */
+        get: operations["UsersController_listUsers"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/users/me": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 自身のプロフィール取得
+         * @description JWTで認証されたユーザー自身のプロフィール情報を取得します。
+         */
+        get: operations["UsersController_getMe"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * 自身のプロフィール更新
+         * @description JWTで認証されたユーザー自身のプロフィール情報を更新します。各フィールドはオプショナルです。
+         */
+        patch: operations["UsersController_updateMe"];
+        trace?: never;
+    };
+    "/api/v1/users/invite": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * ユーザー招待
+         * @description SUPER_ADMINは任意のテナント、TENANT_ADMINは自テナントにユーザーを招待します。
+         */
+        post: operations["UsersController_inviteUser"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/users/{id}/role": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * ユーザーロール変更
+         * @description SUPER_ADMINは任意のユーザー、TENANT_ADMINは自テナントのADMIN/USERのロールを変更します。
+         */
+        patch: operations["UsersController_updateUserRole"];
+        trace?: never;
+    };
+    "/api/v1/users/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * ユーザー削除
+         * @description SUPER_ADMINは任意のユーザー（自分と他のSUPER_ADMINを除く）、TENANT_ADMINは自テナントのADMIN/USERを削除します。
+         */
+        delete: operations["UsersController_deleteUser"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/tenants": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * テナント一覧取得
+         * @description SuperAdminのみが実行可能。全テナントの一覧を取得します。
+         */
+        get: operations["TenantsController_listTenants"];
+        put?: never;
+        /**
+         * テナント作成
+         * @description SuperAdminのみが実行可能。新しいテナントを作成します。
+         */
+        post: operations["TenantsController_createTenant"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/tenants/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * テナント詳細取得
+         * @description SuperAdminまたはテナント管理者（自テナントのみ）が実行可能。指定IDのテナント詳細を取得します。
+         */
+        get: operations["TenantsController_getTenantById"];
+        put?: never;
+        post?: never;
+        /**
+         * テナント削除
+         * @description SuperAdminのみが実行可能。指定IDのテナントを削除します。所属ユーザーがいる場合は削除できません。
+         */
+        delete: operations["TenantsController_deleteTenant"];
+        options?: never;
+        head?: never;
+        /**
+         * テナント更新
+         * @description SuperAdminのみが実行可能。指定IDのテナントを更新します。
+         */
+        patch: operations["TenantsController_updateTenant"];
+        trace?: never;
+    };
+    "/api/v1/tenants/invite-admin": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * テナント管理者を招待
+         * @description SuperAdminのみが実行可能。新しいテナントを作成し、管理者を招待します。
+         */
+        post: operations["TenantsController_inviteTenantAdmin"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/tenants/{tenantId}/users/invite": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * ユーザーを招待
+         * @description テナント管理者が自分のテナントにユーザーを招待します。
+         */
+        post: operations["TenantsController_inviteUser"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/tenants/complete-invitation": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * 招待完了
+         * @description 招待トークンを使用してユーザー登録を完了します。認証不要。
+         */
+        post: operations["TenantsController_completeInvitation"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/tenant-settings/tag-color-defaults": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * タグカラーデフォルト設定を取得
+         * @description テナントのタグカラーデフォルト設定を取得します。設定が存在しない場合はフロントエンドのデフォルト値を返します。
+         */
+        get: operations["TenantSettingsController_getTagColorDefaults"];
+        /**
+         * タグカラーデフォルト設定を更新
+         * @description テナントのタグカラーデフォルト設定を更新します。部分更新をサポートしています。
+         */
+        put: operations["TenantSettingsController_updateTagColorDefaults"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/cats": {
         parameters: {
             query?: never;
@@ -186,6 +426,23 @@ export type paths = {
         };
         /** 猫データの統計情報を取得 */
         get: operations["CatsController_getStatistics"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/cats/kittens": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** 子猫一覧を取得（生後6ヶ月未満、母猫ごとにグループ化） */
+        get: operations["CatsController_findKittens"];
         put?: never;
         post?: never;
         delete?: never;
@@ -247,6 +504,23 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/cats/{id}/family": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** 猫の家族情報を取得（血統タブ用） */
+        get: operations["CatsController_getCatFamily"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/cats/genders": {
         parameters: {
             query?: never;
@@ -258,6 +532,60 @@ export type paths = {
         get: operations["CatsController_getGenders"];
         put?: never;
         post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/cats/{id}/weight-records": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** 猫の体重記録一覧を取得 */
+        get: operations["CatsController_getWeightRecords"];
+        put?: never;
+        /** 猫の体重記録を追加 */
+        post: operations["CatsController_createWeightRecord"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/cats/weight-records/{recordId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** 体重記録を取得 */
+        get: operations["CatsController_getWeightRecord"];
+        put?: never;
+        post?: never;
+        /** 体重記録を削除 */
+        delete: operations["CatsController_deleteWeightRecord"];
+        options?: never;
+        head?: never;
+        /** 体重記録を更新 */
+        patch: operations["CatsController_updateWeightRecord"];
+        trace?: never;
+    };
+    "/api/v1/cats/weight-records/bulk": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** 複数の猫の体重を一括登録 */
+        post: operations["CatsController_createBulkWeightRecords"];
         delete?: never;
         options?: never;
         head?: never;
@@ -276,6 +604,75 @@ export type paths = {
         put?: never;
         /** 血統書データを作成（管理者のみ） */
         post: operations["PedigreeController_create"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/pedigrees/next-id": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** 次の血統書番号を取得 */
+        get: operations["PedigreeController_getNextId"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/pedigrees/print-settings": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** 印刷設定を取得 */
+        get: operations["PedigreeController_getPrintSettings"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** 印刷設定を更新 */
+        patch: operations["PedigreeController_updatePrintSettings"];
+        trace?: never;
+    };
+    "/api/v1/pedigrees/print-settings/reset": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** 印刷設定をデフォルトにリセット */
+        post: operations["PedigreeController_resetPrintSettings"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/pedigrees/pedigree-id/{pedigreeId}/pdf": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** 血統書PDFを生成してダウンロード */
+        get: operations["PedigreeController_generatePdf"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -369,6 +766,102 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/print-templates/categories": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["PrintTemplatesController_getCategories"];
+        put?: never;
+        post: operations["PrintTemplatesController_createCategory"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/print-templates/categories/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["PrintTemplatesController_getCategory"];
+        put?: never;
+        post?: never;
+        delete: operations["PrintTemplatesController_removeCategory"];
+        options?: never;
+        head?: never;
+        patch: operations["PrintTemplatesController_updateCategory"];
+        trace?: never;
+    };
+    "/api/v1/print-templates/data-sources": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["PrintTemplatesController_getDataSources"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/print-templates": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["PrintTemplatesController_findAll"];
+        put?: never;
+        post: operations["PrintTemplatesController_create"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/print-templates/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["PrintTemplatesController_findOne"];
+        put?: never;
+        post?: never;
+        delete: operations["PrintTemplatesController_remove"];
+        options?: never;
+        head?: never;
+        patch: operations["PrintTemplatesController_update"];
+        trace?: never;
+    };
+    "/api/v1/print-templates/{id}/duplicate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["PrintTemplatesController_duplicate"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/breeds": {
         parameters: {
             query?: never;
@@ -381,6 +874,23 @@ export type paths = {
         put?: never;
         /** 品種データを作成（管理者のみ） */
         post: operations["BreedsController_create"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/breeds/master-data": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Pedigree連携用の品種マスターデータを取得 */
+        get: operations["BreedsController_getMasterData"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -423,6 +933,24 @@ export type paths = {
         patch: operations["BreedsController_update"];
         trace?: never;
     };
+    "/api/v1/display-preferences/me": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** 自身の表示設定を取得 */
+        get: operations["DisplayPreferencesController_getMine"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** 自身の表示設定を更新 */
+        patch: operations["DisplayPreferencesController_updateMine"];
+        trace?: never;
+    };
     "/api/v1/coat-colors": {
         parameters: {
             query?: never;
@@ -435,6 +963,23 @@ export type paths = {
         put?: never;
         /** 毛色データを作成（管理者のみ） */
         post: operations["CoatColorsController_create"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/coat-colors/master-data": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Pedigree連携用の色柄マスターデータを取得 */
+        get: operations["CoatColorsController_getMasterData"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -529,23 +1074,6 @@ export type paths = {
         head?: never;
         /** NGペアルールの更新 */
         patch: operations["BreedingController_updateNgRule"];
-        trace?: never;
-    };
-    "/api/v1/breeding/test": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** テスト */
-        get: operations["BreedingController_test"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
         trace?: never;
     };
     "/api/v1/breeding/pregnancy-checks": {
@@ -689,6 +1217,96 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/breeding/schedules": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** 交配スケジュール一覧の取得 */
+        get: operations["BreedingController_findAllBreedingSchedules"];
+        put?: never;
+        /** 交配スケジュールの作成 */
+        post: operations["BreedingController_createBreedingSchedule"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/breeding/schedules/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** 交配スケジュールの削除 */
+        delete: operations["BreedingController_removeBreedingSchedule"];
+        options?: never;
+        head?: never;
+        /** 交配スケジュールの更新 */
+        patch: operations["BreedingController_updateBreedingSchedule"];
+        trace?: never;
+    };
+    "/api/v1/breeding/schedules/{scheduleId}/checks": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** 交配チェック一覧の取得 */
+        get: operations["BreedingController_findMatingChecks"];
+        put?: never;
+        /** 交配チェックの追加 */
+        post: operations["BreedingController_createMatingCheck"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/breeding/mating-checks/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** 交配チェックの削除 */
+        delete: operations["BreedingController_removeMatingCheck"];
+        options?: never;
+        head?: never;
+        /** 交配チェックの更新 */
+        patch: operations["BreedingController_updateMatingCheck"];
+        trace?: never;
+    };
+    "/api/v1/breeding/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** 交配記録の削除 */
+        delete: operations["BreedingController_remove"];
+        options?: never;
+        head?: never;
+        /** 交配記録の更新 */
+        patch: operations["BreedingController_update"];
+        trace?: never;
+    };
     "/api/v1/care/schedules": {
         parameters: {
             query?: never;
@@ -758,6 +1376,25 @@ export type paths = {
         options?: never;
         head?: never;
         patch?: never;
+        trace?: never;
+    };
+    "/api/v1/care/medical-records/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** 医療記録の詳細取得 */
+        get: operations["CareController_findMedicalRecordById"];
+        put?: never;
+        post?: never;
+        /** 医療記録の削除 */
+        delete: operations["CareController_deleteMedicalRecord"];
+        options?: never;
+        head?: never;
+        /** 医療記録の更新 */
+        patch: operations["CareController_updateMedicalRecord"];
         trace?: never;
     };
     "/api/v1/tags": {
@@ -1135,6 +1772,292 @@ export type paths = {
         patch: operations["ShiftController_update"];
         trace?: never;
     };
+    "/api/v1/graduations/cats/{id}/transfer": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** 猫を譲渡（卒業）する */
+        post: operations["GraduationController_transferCat"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/graduations": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** 卒業猫一覧取得 */
+        get: operations["GraduationController_findAllGraduations"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/graduations/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** 卒業猫詳細取得 */
+        get: operations["GraduationController_findOneGraduation"];
+        put?: never;
+        post?: never;
+        /** 卒業取り消し（緊急時用） */
+        delete: operations["GraduationController_cancelGraduation"];
+        options?: never;
+        head?: never;
+        /** 卒業記録の更新 */
+        patch: operations["GraduationController_updateGraduation"];
+        trace?: never;
+    };
+    "/api/v1/gallery/upload/signed-url": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * アップロード用Signed URLを生成
+         * @description クライアントがGCSへ直接アップロードするためのSigned URLを発行します。有効期限は15分です。
+         */
+        post: operations["GalleryUploadController_generateUploadUrl"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/gallery/upload/confirm": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * アップロード完了を確認
+         * @description クライアントがGCSへアップロード完了後に呼び出し、ファイルの存在を確認します。
+         */
+        post: operations["GalleryUploadController_confirmUpload"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/gallery/upload/{fileKey}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * アップロード済みファイルを削除
+         * @description 指定されたファイルキーのファイルをGCSから削除します。
+         */
+        delete: operations["GalleryUploadController_deleteFile"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/gallery": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** ギャラリーエントリ一覧取得 */
+        get: operations["GalleryController_findAll"];
+        put?: never;
+        /** ギャラリーエントリ作成 */
+        post: operations["GalleryController_create"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/gallery/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** ギャラリーエントリ詳細取得 */
+        get: operations["GalleryController_findOne"];
+        /** ギャラリーエントリ更新 */
+        put: operations["GalleryController_update"];
+        post?: never;
+        /** ギャラリーエントリ削除 */
+        delete: operations["GalleryController_delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/gallery/{id}/media": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** メディア追加 */
+        post: operations["GalleryController_addMedia"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/gallery/media/{mediaId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** メディア削除 */
+        delete: operations["GalleryController_deleteMedia"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/gallery/bulk": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** 一括登録（子育て中タブ用） */
+        post: operations["GalleryController_bulkCreate"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/export": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** データをエクスポート */
+        post: operations["ExportController_export"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/import/preview": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** インポートファイルのプレビュー */
+        post: operations["ImportController_preview"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/import/cats": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** 猫データのインポート */
+        post: operations["ImportController_importCats"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/import/pedigrees": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** 血統書データのインポート */
+        post: operations["ImportController_importPedigrees"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/import/tags": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** タグデータのインポート */
+        post: operations["ImportController_importTags"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 };
 export type webhooks = Record<string, never>;
 export type components = {
@@ -1189,6 +2112,140 @@ export type components = {
              */
             refreshToken?: string;
         };
+        UpdateProfileDto: {
+            /**
+             * @description 名
+             * @example 太郎
+             */
+            firstName?: string;
+            /**
+             * @description 姓
+             * @example 山田
+             */
+            lastName?: string;
+            /**
+             * @description メールアドレス
+             * @example user@example.com
+             */
+            email?: string;
+        };
+        InviteUserDto: {
+            /**
+             * @description 招待するメールアドレス
+             * @example user@example.com
+             */
+            email: string;
+            /**
+             * @description ユーザーロール
+             * @default USER
+             * @enum {string}
+             */
+            role: "USER" | "ADMIN" | "SUPER_ADMIN" | "TENANT_ADMIN";
+        };
+        UpdateUserRoleDto: {
+            /**
+             * @description 新しいロール
+             * @example ADMIN
+             * @enum {string}
+             */
+            role: "USER" | "ADMIN" | "SUPER_ADMIN" | "TENANT_ADMIN";
+        };
+        CreateTenantDto: {
+            /**
+             * @description テナント名
+             * @example サンプルテナント
+             */
+            name: string;
+            /**
+             * @description テナントスラッグ（未入力の場合は自動生成）
+             * @example sample-tenant
+             */
+            slug?: string;
+        };
+        UpdateTenantDto: {
+            /**
+             * @description テナント名
+             * @example 更新後テナント名
+             */
+            name?: string;
+            /**
+             * @description テナントスラッグ
+             * @example updated-tenant
+             */
+            slug?: string;
+            /**
+             * @description 有効/無効フラグ
+             * @example true
+             */
+            isActive?: boolean;
+        };
+        InviteTenantAdminDto: {
+            /**
+             * @description 招待するメールアドレス
+             * @example admin@example.com
+             */
+            email: string;
+            /**
+             * @description テナント名
+             * @example Sample Tenant
+             */
+            tenantName: string;
+            /**
+             * @description テナントスラッグ（URL識別子）
+             * @example sample-tenant
+             */
+            tenantSlug?: string;
+        };
+        CompleteInvitationDto: {
+            /** @description 招待トークン */
+            token: string;
+            /** @description パスワード */
+            password: string;
+            /** @description 名 */
+            firstName?: string;
+            /** @description 姓 */
+            lastName?: string;
+        };
+        ColorSettingDto: {
+            /**
+             * @description 背景カラー（16進数カラーコード）
+             * @example #6366F1
+             */
+            color: string;
+            /**
+             * @description テキストカラー（16進数カラーコード）
+             * @example #111827
+             */
+            textColor: string;
+        };
+        TagColorDefaultsDto: {
+            /** @description カテゴリのデフォルトカラー設定 */
+            category?: components["schemas"]["ColorSettingDto"];
+            /** @description グループのデフォルトカラー設定 */
+            group?: components["schemas"]["ColorSettingDto"];
+            /** @description タグのデフォルトカラー設定 */
+            tag?: components["schemas"]["ColorSettingDto"];
+        };
+        PartialColorSettingDto: {
+            /**
+             * @description 背景カラー（16進数カラーコード）
+             * @example #6366F1
+             */
+            color?: string;
+            /**
+             * @description テキストカラー（16進数カラーコード）
+             * @example #111827
+             */
+            textColor?: string;
+        };
+        UpdateTagColorDefaultsDto: {
+            /** @description カテゴリのデフォルトカラー設定（部分更新可能） */
+            category?: components["schemas"]["PartialColorSettingDto"];
+            /** @description グループのデフォルトカラー設定（部分更新可能） */
+            group?: components["schemas"]["PartialColorSettingDto"];
+            /** @description タグのデフォルトカラー設定（部分更新可能） */
+            tag?: components["schemas"]["PartialColorSettingDto"];
+        };
         CreateCatDto: {
             /**
              * @description 猫の名前
@@ -1226,6 +2283,66 @@ export type components = {
             tagIds?: string[];
         };
         UpdateCatDto: Record<string, never>;
+        CreateWeightRecordDto: {
+            /**
+             * @description 体重（グラム単位）
+             * @example 350
+             */
+            weight: number;
+            /**
+             * @description 記録日時（省略時は現在日時）
+             * @example 2024-01-15T10:00:00.000Z
+             */
+            recordedAt?: string;
+            /**
+             * @description メモ
+             * @example ミルクをよく飲んでいる
+             */
+            notes?: string;
+        };
+        UpdateWeightRecordDto: {
+            /**
+             * @description 体重（グラム単位）
+             * @example 380
+             */
+            weight?: number;
+            /**
+             * @description 記録日時
+             * @example 2024-01-15T10:00:00.000Z
+             */
+            recordedAt?: string;
+            /**
+             * @description メモ
+             * @example 順調に成長中
+             */
+            notes?: string;
+        };
+        BulkWeightRecordItemDto: {
+            /**
+             * @description 猫ID
+             * @example 550e8400-e29b-41d4-a716-446655440000
+             */
+            catId: string;
+            /**
+             * @description 体重（グラム単位）
+             * @example 350
+             */
+            weight: number;
+            /**
+             * @description メモ
+             * @example 元気
+             */
+            notes?: string;
+        };
+        CreateBulkWeightRecordsDto: {
+            /**
+             * @description 記録日時（全レコード共通）
+             * @example 2024-01-15T10:00:00.000Z
+             */
+            recordedAt: string;
+            /** @description 体重記録の配列 */
+            records: components["schemas"]["BulkWeightRecordItemDto"][];
+        };
         CreatePedigreeDto: {
             /**
              * @description 血統書番号
@@ -1434,6 +2551,39 @@ export type components = {
             oldCode?: string;
         };
         UpdatePedigreeDto: Record<string, never>;
+        CreatePrintDocCategoryDto: Record<string, never>;
+        UpdatePrintDocCategoryDto: Record<string, never>;
+        CreatePrintTemplateDto: Record<string, never>;
+        DuplicatePrintTemplateDto: Record<string, never>;
+        UpdatePrintTemplateDto: Record<string, never>;
+        MasterDataItemDto: {
+            /**
+             * @description マスターデータのコード
+             * @example 26
+             */
+            code: number;
+            /**
+             * @description CSV 定義のデフォルト名称
+             * @example Maine Coon
+             */
+            name: string;
+            /**
+             * @description 画面に表示される名称。個別設定が無い場合は name と同一。
+             * @example 26 - Maine Coon
+             */
+            displayName?: string;
+            /**
+             * @description このレコードに適用された表示モード
+             * @example CODE_AND_NAME
+             * @enum {string}
+             */
+            displayNameMode?: "CANONICAL" | "CODE_AND_NAME" | "CUSTOM";
+            /**
+             * @description ユーザー上書きが適用された場合に true
+             * @example true
+             */
+            isOverridden?: boolean;
+        };
         CreateBreedDto: {
             /** @description 品種コード */
             code: number;
@@ -1443,6 +2593,34 @@ export type components = {
             description?: string;
         };
         UpdateBreedDto: Record<string, never>;
+        LabelOverrideDto: {
+            /**
+             * @description 対象コード
+             * @example 26
+             */
+            code?: number;
+            /**
+             * @description 表示名の上書き
+             * @example メインクーン
+             */
+            label?: string;
+        };
+        UpdateDisplayPreferenceDto: {
+            /**
+             * @description 品種マスタの表示モード
+             * @enum {string}
+             */
+            breedNameMode?: "CANONICAL" | "CODE_AND_NAME" | "CUSTOM";
+            /**
+             * @description 毛色マスタの表示モード
+             * @enum {string}
+             */
+            coatColorNameMode?: "CANONICAL" | "CODE_AND_NAME" | "CUSTOM";
+            /** @description 品種コードごとの表示名上書き */
+            breedLabelOverrides?: components["schemas"]["LabelOverrideDto"][];
+            /** @description 毛色コードごとの表示名上書き */
+            coatColorLabelOverrides?: components["schemas"]["LabelOverrideDto"][];
+        };
         CreateCoatColorDto: {
             /** @description 毛色コード */
             code: number;
@@ -1643,6 +2821,59 @@ export type components = {
             /** @description メモ */
             notes?: string;
         };
+        CreateBreedingScheduleDto: {
+            /** @description オス猫ID */
+            maleId: string;
+            /** @description メス猫ID */
+            femaleId: string;
+            /** @description 開始日 (ISO8601) */
+            startDate: string;
+            /** @description 期間（日数） */
+            duration: number;
+            /**
+             * @description ステータス
+             * @enum {string}
+             */
+            status?: "SCHEDULED" | "IN_PROGRESS" | "COMPLETED" | "CANCELLED";
+            /** @description メモ */
+            notes?: string;
+        };
+        UpdateBreedingScheduleDto: {
+            /** @description オス猫ID */
+            maleId?: string;
+            /** @description メス猫ID */
+            femaleId?: string;
+            /** @description 開始日 (ISO8601) */
+            startDate?: string;
+            /** @description 期間（日数） */
+            duration?: number;
+            /**
+             * @description ステータス
+             * @enum {string}
+             */
+            status?: "SCHEDULED" | "IN_PROGRESS" | "COMPLETED" | "CANCELLED";
+            /** @description メモ */
+            notes?: string;
+        };
+        CreateMatingCheckDto: {
+            /** @description チェック日 (ISO8601) */
+            checkDate: string;
+            /**
+             * @description チェック回数
+             * @default 1
+             */
+            count: number;
+        };
+        UpdateMatingCheckDto: {
+            /** @description チェック日 (ISO8601) */
+            checkDate?: string;
+            /**
+             * @description チェック回数
+             * @default 1
+             */
+            count: number;
+        };
+        UpdateBreedingDto: Record<string, never>;
         CareScheduleCatDto: {
             /** @example e7b6a7a7-2d7f-4b2f-9f3a-1c2b3d4e5f60 */
             id: string;
@@ -1658,19 +2889,19 @@ export type components = {
              */
             timingType: "ABSOLUTE" | "RELATIVE";
             /** @example 2025-08-01T09:00:00.000Z */
-            remindAt?: string;
+            remindAt?: string | null;
             /** @example 2 */
-            offsetValue?: number;
+            offsetValue?: number | null;
             /**
              * @example DAY
-             * @enum {string}
+             * @enum {string|null}
              */
-            offsetUnit?: "MINUTE" | "HOUR" | "DAY" | "WEEK" | "MONTH";
+            offsetUnit?: "MINUTE" | "HOUR" | "DAY" | "WEEK" | "MONTH" | null;
             /**
              * @example START_DATE
-             * @enum {string}
+             * @enum {string|null}
              */
-            relativeTo?: "START_DATE" | "END_DATE" | "CUSTOM_DATE";
+            relativeTo?: "START_DATE" | "END_DATE" | "CUSTOM_DATE" | null;
             /**
              * @example IN_APP
              * @enum {string}
@@ -1678,17 +2909,17 @@ export type components = {
             channel: "IN_APP" | "EMAIL" | "SMS" | "PUSH";
             /**
              * @example NONE
-             * @enum {string}
+             * @enum {string|null}
              */
-            repeatFrequency?: "NONE" | "DAILY" | "WEEKLY" | "MONTHLY" | "YEARLY" | "CUSTOM";
+            repeatFrequency?: "NONE" | "DAILY" | "WEEKLY" | "MONTHLY" | "YEARLY" | "CUSTOM" | null;
             /** @example 1 */
-            repeatInterval?: number;
+            repeatInterval?: number | null;
             /** @example 5 */
-            repeatCount?: number;
+            repeatCount?: number | null;
             /** @example 2025-12-31T00:00:00.000Z */
-            repeatUntil?: string;
+            repeatUntil?: string | null;
             /** @example 前日9時に通知 */
-            notes?: string;
+            notes?: string | null;
             /** @example true */
             isActive: boolean;
         };
@@ -1702,7 +2933,7 @@ export type components = {
             /** @example 1 */
             level: number;
             /** @example parent-tag-id */
-            parentId?: string;
+            parentId?: string | null;
         };
         CareScheduleItemDto: {
             /** @example a6f7e52f-4a3b-4a76-9870-1234567890ab */
@@ -1712,13 +2943,13 @@ export type components = {
             /** @example 年次健康診断 */
             title: string;
             /** @example 毎年の定期健診 */
-            description: string;
+            description: string | null;
             /** @example 2025-09-01T00:00:00.000Z */
             scheduleDate: string;
             /** @example 2025-09-01T01:00:00.000Z */
-            endDate?: string;
+            endDate?: string | null;
             /** @example Asia/Tokyo */
-            timezone?: string;
+            timezone?: string | null;
             /**
              * @example CARE
              * @enum {string}
@@ -1740,7 +2971,7 @@ export type components = {
              */
             priority: "LOW" | "MEDIUM" | "HIGH" | "URGENT";
             /** @example FREQ=YEARLY;INTERVAL=1 */
-            recurrenceRule?: string;
+            recurrenceRule?: string | null;
             /** @example f3a2c1d7-1234-5678-90ab-cdef12345678 */
             assignedTo: string;
             cat: components["schemas"]["CareScheduleCatDto"] | null;
@@ -1909,24 +3140,40 @@ export type components = {
         CareCompleteResponseDto: {
             /** @example true */
             success: boolean;
-            /** @example {
+            /**
+             * @example {
              *       "scheduleId": "a6f7e52f-4a3b-4a76-9870-1234567890ab",
              *       "recordId": "bcdef123-4567-890a-bcde-f1234567890a",
              *       "medicalRecordId": "f1234567-89ab-cdef-0123-456789abcdef"
-             *     } */
+             *     }
+             */
             data: Record<string, never>;
+        };
+        MedicalRecordVisitTypeDto: {
+            /** @example c4a52a14-8d93-4b87-9f8c-7a6c2ef81234 */
+            id: string;
+            /** @example CHECKUP */
+            key?: Record<string, never>;
+            /** @example 健康診断 */
+            name: string;
+            /** @example 定期的な健康診断 */
+            description?: Record<string, never>;
+            /** @example 1 */
+            displayOrder: number;
+            /** @example true */
+            isActive: boolean;
         };
         MedicalRecordSymptomDto: {
             /** @example くしゃみ */
             label: string;
             /** @example 1週間継続 */
-            note?: string;
+            note?: Record<string, never>;
         };
         MedicalRecordMedicationDto: {
             /** @example 抗生物質 */
             name: string;
             /** @example 朝晩1錠 */
-            dosage?: string;
+            dosage?: Record<string, never>;
         };
         MedicalRecordCatDto: {
             /** @example e7b6a7a7-2d7f-4b2f-9f3a-1c2b3d4e5f60 */
@@ -1943,60 +3190,62 @@ export type components = {
         MedicalRecordTagDto: {
             /** @example tag-123 */
             id: string;
-            /** @example vaccination */
-            slug: string;
             /** @example ワクチン */
-            label: string;
-            /** @example 1 */
-            level: number;
-            /** @example parent-tag */
-            parentId?: string;
+            name: string;
+            /** @example #3B82F6 */
+            color?: Record<string, never>;
+            /** @example #FFFFFF */
+            textColor?: Record<string, never>;
+            /** @example group-123 */
+            groupId: string;
+            /** @example 医療 */
+            groupName?: Record<string, never>;
+            /** @example category-456 */
+            categoryId?: Record<string, never>;
+            /** @example 医療タグ */
+            categoryName?: Record<string, never>;
         };
         MedicalRecordAttachmentDto: {
             /** @example https://cdn.example.com/xray.png */
             url: string;
             /** @example 胸部レントゲン */
-            description?: string;
+            description?: Record<string, never>;
             /** @example xray.png */
-            fileName?: string;
+            fileName?: Record<string, never>;
             /** @example image/png */
-            fileType?: string;
+            fileType?: Record<string, never>;
             /** @example 204800 */
-            fileSize?: number;
+            fileSize?: Record<string, never>;
             /** @example 2025-08-10T09:30:00.000Z */
-            capturedAt?: string;
+            capturedAt?: Record<string, never>;
         };
         MedicalRecordItemDto: {
             /** @example bcdef123-4567-890a-bcde-f1234567890a */
             id: string;
             /** @example 2025-08-10T00:00:00.000Z */
             visitDate: string;
-            /**
-             * @example CHECKUP
-             * @enum {string|null}
-             */
-            visitType: "CHECKUP" | "EMERGENCY" | "SURGERY" | "FOLLOW_UP" | "VACCINATION" | "OTHER" | null;
+            visitType: components["schemas"]["MedicalRecordVisitTypeDto"] | null;
             /** @example ねこクリニック東京 */
-            hospitalName?: string;
+            hospitalName?: Record<string, never>;
             /** @example くしゃみが止まらない */
-            symptom?: string;
+            symptom?: Record<string, never>;
             symptomDetails?: components["schemas"]["MedicalRecordSymptomDto"][];
             /** @example 猫風邪 */
-            diseaseName?: string;
+            diseaseName?: Record<string, never>;
             /** @example 猫風邪の兆候 */
-            diagnosis?: string;
+            diagnosis?: Record<string, never>;
             /** @example 抗生物質を5日間投与 */
-            treatmentPlan?: string;
+            treatmentPlan?: Record<string, never>;
             medications?: components["schemas"]["MedicalRecordMedicationDto"][];
             /** @example 2025-08-13T00:00:00.000Z */
-            followUpDate?: string;
+            followUpDate?: Record<string, never>;
             /**
              * @example TREATING
              * @enum {string}
              */
             status: "TREATING" | "COMPLETED";
             /** @example 食欲は戻ってきた */
-            notes?: string;
+            notes?: Record<string, never>;
             cat: components["schemas"]["MedicalRecordCatDto"];
             schedule?: components["schemas"]["MedicalRecordScheduleDto"] | null;
             tags: components["schemas"]["MedicalRecordTagDto"][];
@@ -2055,10 +3304,10 @@ export type components = {
              */
             visitDate: string;
             /**
-             * @example CHECKUP
-             * @enum {string}
+             * @description 受診種別ID
+             * @example c4a52a14-8d93-4b87-9f8c-7a6c2ef81234
              */
-            visitType?: "CHECKUP" | "EMERGENCY" | "SURGERY" | "FOLLOW_UP" | "VACCINATION" | "OTHER";
+            visitTypeId?: string;
             /** @example ねこクリニック東京 */
             hospitalName?: string;
             /** @example くしゃみが止まらない */
@@ -2081,8 +3330,8 @@ export type components = {
             status: "TREATING" | "COMPLETED";
             /** @example 食欲も戻りつつあり */
             notes?: string;
-            /** @description 関連ケアタグID */
-            careTagIds?: string[];
+            /** @description 関連タグID */
+            tagIds?: string[];
             /** @description 添付ファイル */
             attachments?: components["schemas"]["MedicalRecordAttachmentInputDto"][];
         };
@@ -2090,6 +3339,54 @@ export type components = {
             /** @example true */
             success: boolean;
             data: components["schemas"]["MedicalRecordItemDto"];
+        };
+        UpdateMedicalRecordDto: {
+            /**
+             * @description 猫ID
+             * @example e7b6a7a7-2d7f-4b2f-9f3a-1c2b3d4e5f60
+             */
+            catId?: string;
+            /**
+             * @description スケジュールID
+             * @example a6f7e52f-4a3b-4a76-9870-1234567890ab
+             */
+            scheduleId?: string;
+            /**
+             * @description 受診日
+             * @example 2025-08-10
+             */
+            visitDate?: string;
+            /**
+             * @description 受診種別ID
+             * @example c4a52a14-8d93-4b87-9f8c-7a6c2ef81234
+             */
+            visitTypeId?: string;
+            /** @example ねこクリニック東京 */
+            hospitalName?: string;
+            /** @example くしゃみが止まらない */
+            symptom?: string;
+            symptomDetails?: components["schemas"]["MedicalRecordSymptomDto"][];
+            /** @example 猫風邪 */
+            diseaseName?: string;
+            /** @example 猫風邪の兆候 */
+            diagnosis?: string;
+            /** @example 抗生物質を5日間投与 */
+            treatmentPlan?: string;
+            medications?: components["schemas"]["MedicalRecordMedicationDto"][];
+            /** @example 2025-08-13 */
+            followUpDate?: string;
+            /**
+             * @default TREATING
+             * @example TREATING
+             * @enum {string}
+             */
+            status: "TREATING" | "COMPLETED";
+            /** @example 食欲も戻りつつあり */
+            notes?: string;
+            /** @description 関連タグID */
+            tagIds?: string[];
+            /** @description 添付ファイル */
+            attachments?: components["schemas"]["MedicalRecordAttachmentInputDto"][];
         };
         CreateTagDto: {
             /**
@@ -2388,10 +3685,10 @@ export type components = {
         CreateTagAutomationRuleDto: {
             /** @description ルールの一意なキー（自動生成可能） */
             key?: string;
-            /** @description ルール名 */
-            name: string;
+            /** @description ルール名（未入力時は自動生成） */
+            name?: string;
             /** @description ルールの説明 */
-            description?: string;
+            description?: Record<string, never>;
             /**
              * @description トリガータイプ
              * @example EVENT
@@ -2400,15 +3697,15 @@ export type components = {
             triggerType: "EVENT" | "SCHEDULE" | "MANUAL";
             /**
              * @description イベントタイプ
-             * @example BREEDING_PLANNED
+             * @example PAGE_ACTION
              * @enum {string}
              */
-            eventType: "BREEDING_PLANNED" | "BREEDING_CONFIRMED" | "PREGNANCY_CONFIRMED" | "KITTEN_REGISTERED" | "AGE_THRESHOLD" | "PAGE_ACTION" | "CUSTOM";
+            eventType?: "BREEDING_PLANNED" | "BREEDING_CONFIRMED" | "PREGNANCY_CONFIRMED" | "KITTEN_REGISTERED" | "AGE_THRESHOLD" | "CUSTOM" | "PAGE_ACTION" | "TAG_ASSIGNED";
             /**
              * @description 適用範囲（スコープ）
              * @example breeding
              */
-            scope?: string;
+            scope?: Record<string, never>;
             /**
              * @description ルールが有効かどうか
              * @default true
@@ -2425,7 +3722,8 @@ export type components = {
              *       "tagIds": [
              *         "tag-id-1",
              *         "tag-id-2"
-             *       ]
+             *       ],
+             *       "actionType": "ASSIGN"
              *     }
              */
             config?: Record<string, never>;
@@ -2433,10 +3731,10 @@ export type components = {
         UpdateTagAutomationRuleDto: {
             /** @description ルールの一意なキー（自動生成可能） */
             key?: string;
-            /** @description ルール名 */
+            /** @description ルール名（未入力時は自動生成） */
             name?: string;
             /** @description ルールの説明 */
-            description?: string;
+            description?: Record<string, never>;
             /**
              * @description トリガータイプ
              * @example EVENT
@@ -2445,15 +3743,15 @@ export type components = {
             triggerType?: "EVENT" | "SCHEDULE" | "MANUAL";
             /**
              * @description イベントタイプ
-             * @example BREEDING_PLANNED
+             * @example PAGE_ACTION
              * @enum {string}
              */
-            eventType?: "BREEDING_PLANNED" | "BREEDING_CONFIRMED" | "PREGNANCY_CONFIRMED" | "KITTEN_REGISTERED" | "AGE_THRESHOLD" | "PAGE_ACTION" | "CUSTOM";
+            eventType?: "BREEDING_PLANNED" | "BREEDING_CONFIRMED" | "PREGNANCY_CONFIRMED" | "KITTEN_REGISTERED" | "AGE_THRESHOLD" | "CUSTOM" | "PAGE_ACTION" | "TAG_ASSIGNED";
             /**
              * @description 適用範囲（スコープ）
              * @example breeding
              */
-            scope?: string;
+            scope?: Record<string, never>;
             /**
              * @description ルールが有効かどうか
              * @default true
@@ -2470,7 +3768,8 @@ export type components = {
              *       "tagIds": [
              *         "tag-id-1",
              *         "tag-id-2"
-             *       ]
+             *       ],
+             *       "actionType": "ASSIGN"
              *     }
              */
             config?: Record<string, never>;
@@ -2479,6 +3778,193 @@ export type components = {
         UpdateStaffDto: Record<string, never>;
         CreateShiftDto: Record<string, never>;
         UpdateShiftDto: Record<string, never>;
+        TransferCatDto: {
+            /**
+             * @description 譲渡日
+             * @example 2025-11-11
+             */
+            transferDate: string;
+            /**
+             * @description 譲渡先
+             * @example 山田家
+             */
+            destination: string;
+            /**
+             * @description 備考
+             * @example 譲渡先は愛情深い家庭です
+             */
+            notes?: string;
+        };
+        UpdateGraduationDto: {
+            /**
+             * @description 譲渡日
+             * @example 2025-11-11
+             */
+            transferDate?: string;
+            /**
+             * @description 譲渡先
+             * @example 山田家
+             */
+            destination?: string;
+            /**
+             * @description 備考
+             * @example 譲渡先は愛情深い家庭です
+             */
+            notes?: string;
+        };
+        GenerateUploadUrlDto: {
+            /**
+             * @description ファイル名
+             * @example kitten-photo-1.jpg
+             */
+            fileName: string;
+            /**
+             * @description コンテンツタイプ
+             * @example image/jpeg
+             * @enum {string}
+             */
+            contentType: "image/jpeg" | "image/png" | "image/webp";
+            /**
+             * @description ファイルサイズ（バイト）
+             * @example 1024000
+             */
+            fileSize: number;
+        };
+        ConfirmUploadDto: {
+            /**
+             * @description アップロード時に発行されたファイルキー
+             * @example gallery/550e8400-e29b-41d4-a716-446655440000.jpg
+             */
+            fileKey: string;
+            /**
+             * @description 紐付けるギャラリーエントリID（任意）
+             * @example 550e8400-e29b-41d4-a716-446655440001
+             */
+            galleryEntryId?: string;
+        };
+        CreateMediaDto: {
+            /**
+             * @description メディアタイプ
+             * @enum {string}
+             */
+            type: "IMAGE" | "YOUTUBE";
+            /** @description メディアURL */
+            url: string;
+            /** @description サムネイルURL（YouTube用） */
+            thumbnailUrl?: string;
+            /** @description 表示順序 */
+            order?: number;
+        };
+        CreateGalleryEntryDto: {
+            /**
+             * @description カテゴリ
+             * @enum {string}
+             */
+            category: "KITTEN" | "FATHER" | "MOTHER" | "GRADUATION";
+            /** @description 猫の名前 */
+            name: string;
+            /**
+             * @description 性別
+             * @enum {string}
+             */
+            gender: "MALE" | "FEMALE" | "NEUTER" | "SPAY";
+            /** @description 毛色 */
+            coatColor?: string;
+            /** @description 品種 */
+            breed?: string;
+            /** @description 在舎猫ID（参照用） */
+            catId?: string;
+            /** @description 譲渡日（卒業猫用） */
+            transferDate?: string;
+            /** @description 譲渡先（卒業猫用） */
+            destination?: string;
+            /** @description 外部リンク（卒業猫用） */
+            externalLink?: string;
+            /** @description 備考 */
+            notes?: string;
+            /** @description メディア（画像・動画） */
+            media?: components["schemas"]["CreateMediaDto"][];
+        };
+        UpdateGalleryEntryDto: {
+            /**
+             * @description カテゴリ
+             * @enum {string}
+             */
+            category?: "KITTEN" | "FATHER" | "MOTHER" | "GRADUATION";
+            /** @description 猫の名前 */
+            name?: string;
+            /**
+             * @description 性別
+             * @enum {string}
+             */
+            gender?: "MALE" | "FEMALE" | "NEUTER" | "SPAY";
+            /** @description 毛色 */
+            coatColor?: string;
+            /** @description 品種 */
+            breed?: string;
+            /** @description 在舎猫ID（参照用） */
+            catId?: string;
+            /** @description 譲渡日（卒業猫用） */
+            transferDate?: string;
+            /** @description 譲渡先（卒業猫用） */
+            destination?: string;
+            /** @description 外部リンク（卒業猫用） */
+            externalLink?: string;
+            /** @description 備考 */
+            notes?: string;
+            /** @description メディア（画像・動画） */
+            media?: components["schemas"]["CreateMediaDto"][];
+        };
+        AddMediaDto: {
+            /**
+             * @description メディアタイプ
+             * @enum {string}
+             */
+            type: "IMAGE" | "YOUTUBE";
+            /** @description メディアURL */
+            url: string;
+            /** @description サムネイルURL（YouTube用） */
+            thumbnailUrl?: string;
+        };
+        ExportRequestDto: {
+            /**
+             * @description エクスポート対象データ種別
+             * @enum {string}
+             */
+            dataType: "cats" | "pedigrees" | "medical_records" | "care_schedules" | "tags";
+            /**
+             * @description エクスポート形式
+             * @default csv
+             * @enum {string}
+             */
+            format: "csv" | "json";
+            /** @description 開始日（フィルタ用） */
+            startDate?: string;
+            /** @description 終了日（フィルタ用） */
+            endDate?: string;
+            /** @description 対象IDリスト（特定データのみエクスポート） */
+            ids?: string[];
+        };
+        ImportPreviewDto: {
+            /** @description プレビューデータ件数 */
+            previewCount: number;
+            /** @description サンプルデータ（最初の5件） */
+            sampleData: unknown[];
+            /** @description 検出されたカラム */
+            columns: string[];
+            /** @description データ総件数 */
+            totalCount: number;
+        };
+        ImportResultDto: {
+            /** @description インポート成功件数 */
+            successCount: number;
+            /** @description インポート失敗件数 */
+            errorCount: number;
+            /** @description 処理総件数 */
+            totalCount: number;
+            /** @description エラー詳細（最初の10件） */
+            errors?: string[];
+        };
     };
     responses: never;
     parameters: never;
@@ -2679,6 +4165,687 @@ export interface operations {
             };
         };
     };
+    UsersController_listUsers: {
+        parameters: {
+            query?: {
+                /** @description テナント ID でフィルタ（SUPER_ADMIN のみ有効） */
+                tenantId?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description ユーザー一覧を返却 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 認証が必要です */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 権限がありません */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    UsersController_getMe: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description プロフィール情報を返却 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 認証が必要です */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description ユーザーが見つかりません */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    UsersController_updateMe: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateProfileDto"];
+            };
+        };
+        responses: {
+            /** @description プロフィールが更新されました */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 更新するフィールドがありません */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 認証が必要です */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description メールアドレスが既に使用されています */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    UsersController_inviteUser: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["InviteUserDto"];
+            };
+        };
+        responses: {
+            /** @description 招待が作成されました */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 認証が必要です */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 権限がありません */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description テナントが見つかりません */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description メールアドレスが既に使用されています */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    UsersController_updateUserRole: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description 対象ユーザー ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateUserRoleDto"];
+            };
+        };
+        responses: {
+            /** @description ロールが更新されました */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 認証が必要です */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 権限がありません */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description ユーザーが見つかりません */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    UsersController_deleteUser: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description 対象ユーザー ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description ユーザーが削除されました */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 認証が必要です */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 権限がありません */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description ユーザーが見つかりません */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    TenantsController_listTenants: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description テナント一覧を返却 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 認証が必要です */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 権限がありません */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    TenantsController_createTenant: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateTenantDto"];
+            };
+        };
+        responses: {
+            /** @description テナントが作成されました */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 不正なリクエスト */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 権限がありません */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description スラッグが既に使用されています */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    TenantsController_getTenantById: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description テナント詳細を返却 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 認証が必要です */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 権限がありません */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description テナントが見つかりません */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    TenantsController_deleteTenant: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description テナントが削除されました */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 認証が必要です */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 権限がありません */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description テナントが見つかりません */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 所属ユーザーが存在するため削除できません */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    TenantsController_updateTenant: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateTenantDto"];
+            };
+        };
+        responses: {
+            /** @description テナントが更新されました */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 認証が必要です */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 権限がありません */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description テナントが見つかりません */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description スラッグが既に使用されています */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    TenantsController_inviteTenantAdmin: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["InviteTenantAdminDto"];
+            };
+        };
+        responses: {
+            /** @description 招待が正常に作成されました */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 不正なリクエスト */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 権限がありません */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description メールアドレスまたはスラッグが既に使用されています */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    TenantsController_inviteUser: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                tenantId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["InviteUserDto"];
+            };
+        };
+        responses: {
+            /** @description 招待が正常に作成されました */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 不正なリクエスト */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 権限がありません */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description テナントが見つかりません */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description メールアドレスが既に使用されています */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    TenantsController_completeInvitation: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CompleteInvitationDto"];
+            };
+        };
+        responses: {
+            /** @description ユーザー登録が完了しました */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 不正なリクエストまたは無効なトークン */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description メールアドレスが既に使用されています */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    TenantSettingsController_getTagColorDefaults: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description タグカラーデフォルト設定を返却 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TagColorDefaultsDto"];
+                };
+            };
+            /** @description 認証が必要です */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description テナントが見つかりません */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    TenantSettingsController_updateTagColorDefaults: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateTagColorDefaultsDto"];
+            };
+        };
+        responses: {
+            /** @description タグカラーデフォルト設定が更新されました */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TagColorDefaultsDto"];
+                };
+            };
+            /** @description 不正なリクエスト */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 認証が必要です */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 権限がありません */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description テナントが見つかりません */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
     CatsController_findAll: {
         parameters: {
             query?: {
@@ -2694,6 +4861,8 @@ export interface operations {
                 coatColorId?: string;
                 /** @description 性別 */
                 gender?: "MALE" | "FEMALE" | "NEUTER" | "SPAY" | "1" | "2" | "3" | "4";
+                /** @description 在舎中フィルター */
+                isInHouse?: boolean;
                 /** @description 最小年齢 */
                 ageMin?: number;
                 /** @description 最大年齢 */
@@ -2759,6 +4928,37 @@ export interface operations {
         requestBody?: never;
         responses: {
             /** @description 統計情報 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    CatsController_findKittens: {
+        parameters: {
+            query?: {
+                /** @description 母猫ID（指定時はその母猫の子猫のみ取得） */
+                motherId?: string;
+                /** @description ページ番号 */
+                page?: number;
+                /** @description 1ページあたりの件数 */
+                limit?: number;
+                /** @description 検索キーワード（子猫名） */
+                search?: string;
+                /** @description ソート項目 */
+                sortBy?: string;
+                /** @description ソート順 */
+                sortOrder?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description 子猫データの一覧（母猫ごとにグループ化） */
             200: {
                 headers: {
                     [name: string]: unknown;
@@ -2918,6 +5118,34 @@ export interface operations {
             };
         };
     };
+    CatsController_getCatFamily: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description 猫データのID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description 家族情報（親・兄弟姉妹・子猫） */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 猫データが見つかりません */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
     CatsController_getGenders: {
         parameters: {
             query?: never;
@@ -2929,6 +5157,208 @@ export interface operations {
         responses: {
             /** @description 性別マスタデータを返却 */
             200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    CatsController_getWeightRecords: {
+        parameters: {
+            query?: {
+                /** @description ページ番号 */
+                page?: number;
+                /** @description 1ページあたりの件数 */
+                limit?: number;
+                /** @description 開始日 */
+                startDate?: string;
+                /** @description 終了日 */
+                endDate?: string;
+                /** @description ソート順 */
+                sortOrder?: string;
+            };
+            header?: never;
+            path: {
+                /** @description 猫データのID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description 体重記録一覧 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 猫データが見つかりません */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    CatsController_createWeightRecord: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description 猫データのID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateWeightRecordDto"];
+            };
+        };
+        responses: {
+            /** @description 体重記録が正常に作成されました */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 無効なデータです */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 猫データが見つかりません */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    CatsController_getWeightRecord: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description 体重記録のID */
+                recordId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description 体重記録 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 体重記録が見つかりません */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    CatsController_deleteWeightRecord: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description 体重記録のID */
+                recordId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description 体重記録が正常に削除されました */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 体重記録が見つかりません */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    CatsController_updateWeightRecord: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description 体重記録のID */
+                recordId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateWeightRecordDto"];
+            };
+        };
+        responses: {
+            /** @description 体重記録が正常に更新されました */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 無効なデータです */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 体重記録が見つかりません */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    CatsController_createBulkWeightRecords: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateBulkWeightRecordsDto"];
+            };
+        };
+        responses: {
+            /** @description 体重記録が正常に一括作成されました */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 無効なデータです */
+            400: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -3004,6 +5434,120 @@ export interface operations {
             };
             /** @description 管理者権限が必要です */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    PedigreeController_getNextId: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description 次の血統書番号 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    PedigreeController_getPrintSettings: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description 現在の印刷設定 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    PedigreeController_updatePrintSettings: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description 更新後の印刷設定 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 無効な設定データです */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    PedigreeController_resetPrintSettings: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description リセット後の印刷設定 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    PedigreeController_generatePdf: {
+        parameters: {
+            query?: {
+                /** @description 出力形式 (pdf|base64) */
+                format?: string;
+                /** @description デバッグモード（背景画像表示） */
+                debug?: string;
+            };
+            header?: never;
+            path: {
+                /** @description 血統書番号 */
+                pedigreeId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description PDF生成成功 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"];
+                };
+            };
+            /** @description 血統書データが見つかりません */
+            404: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -3235,6 +5779,246 @@ export interface operations {
             };
         };
     };
+    PrintTemplatesController_getCategories: {
+        parameters: {
+            query: {
+                tenantId: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    PrintTemplatesController_createCategory: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreatePrintDocCategoryDto"];
+            };
+        };
+        responses: {
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    PrintTemplatesController_getCategory: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    PrintTemplatesController_removeCategory: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    PrintTemplatesController_updateCategory: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdatePrintDocCategoryDto"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    PrintTemplatesController_getDataSources: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    PrintTemplatesController_findAll: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    PrintTemplatesController_create: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreatePrintTemplateDto"];
+            };
+        };
+        responses: {
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    PrintTemplatesController_findOne: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    PrintTemplatesController_remove: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    PrintTemplatesController_update: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdatePrintTemplateDto"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    PrintTemplatesController_duplicate: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DuplicatePrintTemplateDto"];
+            };
+        };
+        responses: {
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
     BreedsController_findAll: {
         parameters: {
             query?: {
@@ -3297,6 +6081,26 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+        };
+    };
+    BreedsController_getMasterData: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description CSV マスターデータを displayName / displayNameMode 付きで返却 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MasterDataItemDto"][];
+                };
             };
         };
     };
@@ -3427,6 +6231,46 @@ export interface operations {
             };
         };
     };
+    DisplayPreferencesController_getMine: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description 表示設定の取得に成功 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    DisplayPreferencesController_updateMine: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateDisplayPreferenceDto"];
+            };
+        };
+        responses: {
+            /** @description 表示設定の更新に成功 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
     CoatColorsController_findAll: {
         parameters: {
             query?: {
@@ -3489,6 +6333,26 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+        };
+    };
+    CoatColorsController_getMasterData: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description CSV マスターデータを displayName / displayNameMode 付きで返却 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MasterDataItemDto"][];
+                };
             };
         };
     };
@@ -3741,23 +6605,6 @@ export interface operations {
                 "application/json": components["schemas"]["UpdateBreedingNgRuleDto"];
             };
         };
-        responses: {
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    BreedingController_test: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
         responses: {
             200: {
                 headers: {
@@ -4046,6 +6893,227 @@ export interface operations {
             };
         };
     };
+    BreedingController_findAllBreedingSchedules: {
+        parameters: {
+            query?: {
+                /** @description ページ番号 */
+                page?: number;
+                /** @description 1ページあたりの件数 */
+                limit?: number;
+                /** @description オス猫IDでフィルタ */
+                maleId?: string;
+                /** @description メス猫IDでフィルタ */
+                femaleId?: string;
+                /** @description ステータスでフィルタ */
+                status?: "SCHEDULED" | "IN_PROGRESS" | "COMPLETED" | "CANCELLED";
+                /** @description 開始日（from） */
+                dateFrom?: string;
+                /** @description 開始日（to） */
+                dateTo?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    BreedingController_createBreedingSchedule: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateBreedingScheduleDto"];
+            };
+        };
+        responses: {
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    BreedingController_removeBreedingSchedule: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    BreedingController_updateBreedingSchedule: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateBreedingScheduleDto"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    BreedingController_findMatingChecks: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                scheduleId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    BreedingController_createMatingCheck: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                scheduleId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateMatingCheckDto"];
+            };
+        };
+        responses: {
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    BreedingController_removeMatingCheck: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    BreedingController_updateMatingCheck: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateMatingCheckDto"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    BreedingController_remove: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    BreedingController_update: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateBreedingDto"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
     CareController_findSchedules: {
         parameters: {
             query?: {
@@ -4180,7 +7248,8 @@ export interface operations {
                 catId?: string;
                 /** @description スケジュールID */
                 scheduleId?: string;
-                visitType?: "CHECKUP" | "EMERGENCY" | "SURGERY" | "FOLLOW_UP" | "VACCINATION" | "OTHER";
+                /** @description 受診種別ID */
+                visitTypeId?: string;
                 status?: "TREATING" | "COMPLETED";
                 /** @description 受診開始日 */
                 dateFrom?: string;
@@ -4217,6 +7286,75 @@ export interface operations {
         };
         responses: {
             201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MedicalRecordResponseDto"];
+                };
+            };
+        };
+    };
+    CareController_findMedicalRecordById: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description 医療記録ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MedicalRecordResponseDto"];
+                };
+            };
+        };
+    };
+    CareController_deleteMedicalRecord: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description 医療記録ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description 削除成功 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    CareController_updateMedicalRecord: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description 医療記録ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateMedicalRecordDto"];
+            };
+        };
+        responses: {
+            200: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5005,6 +8143,667 @@ export interface operations {
         };
         responses: {
             200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    GraduationController_transferCat: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description 猫ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["TransferCatDto"];
+            };
+        };
+        responses: {
+            /** @description 譲渡成功 */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description すでに卒業済みです */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 猫が見つかりません */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    GraduationController_findAllGraduations: {
+        parameters: {
+            query?: {
+                page?: number;
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description 卒業猫一覧 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    GraduationController_findOneGraduation: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description 卒業ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description 卒業猫詳細 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 卒業記録が見つかりません */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    GraduationController_cancelGraduation: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description 卒業ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description 卒業取り消し成功 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 卒業記録が見つかりません */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    GraduationController_updateGraduation: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description 卒業ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateGraduationDto"];
+            };
+        };
+        responses: {
+            /** @description 更新成功 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 卒業記録が見つかりません */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    GalleryUploadController_generateUploadUrl: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["GenerateUploadUrlDto"];
+            };
+        };
+        responses: {
+            /** @description Signed URL生成成功 */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example true */
+                        success?: boolean;
+                        data?: {
+                            /** @description アップロード用Signed URL */
+                            uploadUrl?: string;
+                            /** @description GCS内のファイルキー */
+                            fileKey?: string;
+                            /** @description アップロード後の公開URL */
+                            publicUrl?: string;
+                        };
+                    };
+                };
+            };
+            /** @description パラメータエラー */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    GalleryUploadController_confirmUpload: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ConfirmUploadDto"];
+            };
+        };
+        responses: {
+            /** @description 確認成功 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example true */
+                        success?: boolean;
+                        data?: {
+                            /** @example true */
+                            success?: boolean;
+                            /** @description ファイルの公開URL */
+                            url?: string;
+                            /** @description ファイルサイズ（バイト） */
+                            size?: number;
+                        };
+                    };
+                };
+            };
+            /** @description ファイルが見つからない */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    GalleryUploadController_deleteFile: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description 削除するファイルのキー（URLエンコード済み） */
+                fileKey: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description 削除成功 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    GalleryController_findAll: {
+        parameters: {
+            query?: {
+                /** @description カテゴリでフィルタリング */
+                category?: "KITTEN" | "FATHER" | "MOTHER" | "GRADUATION";
+                /** @description ページ番号 */
+                page?: number;
+                /** @description 1ページあたりの件数 */
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description ギャラリー一覧 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    GalleryController_create: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateGalleryEntryDto"];
+            };
+        };
+        responses: {
+            /** @description 作成成功 */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    GalleryController_findOne: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description エントリID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description ギャラリー詳細 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description エントリが見つかりません */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    GalleryController_update: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description エントリID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateGalleryEntryDto"];
+            };
+        };
+        responses: {
+            /** @description 更新成功 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description エントリが見つかりません */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    GalleryController_delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description エントリID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description 削除成功 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description エントリが見つかりません */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    GalleryController_addMedia: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description エントリID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AddMediaDto"];
+            };
+        };
+        responses: {
+            /** @description メディア追加成功 */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    GalleryController_deleteMedia: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description メディアID */
+                mediaId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description メディア削除成功 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    GalleryController_bulkCreate: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": string[];
+            };
+        };
+        responses: {
+            /** @description 一括登録成功 */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    ExportController_export: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ExportRequestDto"];
+            };
+        };
+        responses: {
+            /** @description エクスポート成功 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 無効なリクエスト */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    ImportController_preview: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "multipart/form-data": {
+                    /**
+                     * Format: binary
+                     * @description CSVファイル
+                     */
+                    file: string;
+                };
+            };
+        };
+        responses: {
+            /** @description プレビュー取得成功 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ImportPreviewDto"];
+                };
+            };
+            /** @description ファイルが不正な形式 */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 認証が必要 */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    ImportController_importCats: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "multipart/form-data": {
+                    /**
+                     * Format: binary
+                     * @description CSVファイル（カラム: name, gender, birthDate, breed, color, registrationNumber, microchipNumber, notes）
+                     */
+                    file: string;
+                };
+            };
+        };
+        responses: {
+            /** @description インポート完了 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ImportResultDto"];
+                };
+            };
+            /** @description ファイルが不正な形式 */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 認証が必要 */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    ImportController_importPedigrees: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "multipart/form-data": {
+                    /**
+                     * Format: binary
+                     * @description CSVファイル（カラム: pedigreeId, catName, title, breedCode, genderCode, coatColorCode）
+                     */
+                    file: string;
+                };
+            };
+        };
+        responses: {
+            /** @description インポート完了 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ImportResultDto"];
+                };
+            };
+            /** @description ファイルが不正な形式 */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 認証が必要 */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    ImportController_importTags: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "multipart/form-data": {
+                    /**
+                     * Format: binary
+                     * @description CSVファイル（カラム: name, category, group, color, isActive）
+                     */
+                    file: string;
+                };
+            };
+        };
+        responses: {
+            /** @description インポート完了 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ImportResultDto"];
+                };
+            };
+            /** @description ファイルが不正な形式 */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 認証が必要 */
+            401: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/frontend/src/lib/api/generated/schema.ts
+++ b/frontend/src/lib/api/generated/schema.ts
@@ -451,6 +451,23 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/cats/genders": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** 性別マスタデータを取得 */
+        get: operations["CatsController_getGenders"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/cats/{id}": {
         parameters: {
             query?: never;
@@ -513,23 +530,6 @@ export type paths = {
         };
         /** 猫の家族情報を取得（血統タブ用） */
         get: operations["CatsController_getCatFamily"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/cats/genders": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** 性別マスタデータを取得 */
-        get: operations["CatsController_getGenders"];
         put?: never;
         post?: never;
         delete?: never;
@@ -5006,6 +5006,24 @@ export interface operations {
             };
         };
     };
+    CatsController_getGenders: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description 性別マスタデータを返却 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
     CatsController_findOne: {
         parameters: {
             query?: never;
@@ -5178,24 +5196,6 @@ export interface operations {
             };
             /** @description 猫データが見つかりません */
             404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    CatsController_getGenders: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description 性別マスタデータを返却 */
-            200: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/frontend/src/lib/api/generated/schema.ts
+++ b/frontend/src/lib/api/generated/schema.ts
@@ -1360,6 +1360,23 @@ export type paths = {
         patch: operations["CareController_updateSchedule"];
         trace?: never;
     };
+    "/api/v1/care/schedules/{id}/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** ケアスケジュールのステータス変更（有効/無効） */
+        patch: operations["CareController_updateScheduleStatus"];
+        trace?: never;
+    };
     "/api/v1/care/medical-records": {
         parameters: {
             query?: never;
@@ -2656,6 +2673,11 @@ export type components = {
              * @example 初回の交配。
              */
             notes?: string;
+            /**
+             * @description NGペアルール違反時でも強行登録する場合に true
+             * @example false
+             */
+            force?: boolean;
         };
         CreateBreedingNgRuleDto: {
             /**
@@ -2837,6 +2859,11 @@ export type components = {
             status?: "SCHEDULED" | "IN_PROGRESS" | "COMPLETED" | "CANCELLED";
             /** @description メモ */
             notes?: string;
+            /**
+             * @description NGペアルール違反時でも強行登録する場合に true
+             * @example false
+             */
+            force?: boolean;
         };
         UpdateBreedingScheduleDto: {
             /** @description オス猫ID */
@@ -2854,6 +2881,11 @@ export type components = {
             status?: "SCHEDULED" | "IN_PROGRESS" | "COMPLETED" | "CANCELLED";
             /** @description メモ */
             notes?: string;
+            /**
+             * @description NGペアルール違反時でも強行登録する場合に true
+             * @example false
+             */
+            force?: boolean;
         };
         CreateMatingCheckDto: {
             /** @description チェック日 (ISO8601) */
@@ -3148,6 +3180,13 @@ export type components = {
              *     }
              */
             data: Record<string, never>;
+        };
+        UpdateCareStatusDto: {
+            /**
+             * @example PENDING
+             * @enum {string}
+             */
+            status: "PENDING" | "IN_PROGRESS" | "COMPLETED" | "CANCELLED";
         };
         MedicalRecordVisitTypeDto: {
             /** @example c4a52a14-8d93-4b87-9f8c-7a6c2ef81234 */
@@ -7226,6 +7265,32 @@ export interface operations {
         requestBody: {
             content: {
                 "application/json": components["schemas"]["CreateCareScheduleDto"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CareScheduleResponseDto"];
+                };
+            };
+        };
+    };
+    CareController_updateScheduleStatus: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description スケジュールID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateCareStatusDto"];
             };
         };
         responses: {

--- a/frontend/src/lib/api/generated/schema.ts
+++ b/frontend/src/lib/api/generated/schema.ts
@@ -1652,7 +1652,7 @@ export type paths = {
         };
         get?: never;
         put?: never;
-        /** ルールを手動実行（テスト用） */
+        /** ルールを手動実行（実データの対象猫に即時適用） */
         post: operations["TagAutomationController_executeRule"];
         delete?: never;
         options?: never;
@@ -7890,7 +7890,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description ルール実行成功 */
+            /** @description ルール実行結果 */
             200: {
                 headers: {
                     [name: string]: unknown;

--- a/frontend/src/lib/api/hooks/use-breeding.ts
+++ b/frontend/src/lib/api/hooks/use-breeding.ts
@@ -824,6 +824,8 @@ export type CreateBreedingScheduleRequest = {
   duration: number;
   status?: BreedingScheduleStatus;
   notes?: string;
+  /** NGペアルール違反時の強行登録フラグ */
+  force?: boolean;
 };
 
 export type UpdateBreedingScheduleRequest = Partial<CreateBreedingScheduleRequest>;

--- a/frontend/src/lib/api/hooks/use-breeding.ts
+++ b/frontend/src/lib/api/hooks/use-breeding.ts
@@ -792,8 +792,8 @@ export interface MatingCheck {
 
 export interface BreedingSchedule {
   id: string;
-  maleId: string;
-  femaleId: string;
+  maleId: string | null;
+  femaleId: string | null;
   startDate: string;
   duration: number;
   status: BreedingScheduleStatus;
@@ -803,6 +803,9 @@ export interface BreedingSchedule {
   updatedAt: string;
   male?: { id: string; name: string | null } | null;
   female?: { id: string; name: string | null } | null;
+  /** 猫削除後に名前をテキストで保持するスナップショット */
+  maleName?: string | null;
+  femaleName?: string | null;
   checks?: MatingCheck[];
 }
 

--- a/frontend/src/lib/api/hooks/use-care.ts
+++ b/frontend/src/lib/api/hooks/use-care.ts
@@ -182,6 +182,7 @@ export interface MedicalRecordResponse {
 
 export type GetMedicalRecordsParams = ApiQueryParams<'/care/medical-records', 'get'>;
 export type CreateMedicalRecordRequest = ApiRequestBody<'/care/medical-records', 'post'>;
+export type UpdateMedicalRecordRequest = ApiRequestBody<'/care/medical-records/{id}', 'patch'>;
 
 const medicalRecordKeys = createDomainQueryKeys<string, GetMedicalRecordsParams>('medical-records');
 
@@ -398,6 +399,71 @@ export function useCreateMedicalRecord() {
     onError: (error: Error) => {
       notifications.show({
         title: '医療記録の登録に失敗しました',
+        message: error.message ?? '時間をおいて再度お試しください。',
+        color: 'red',
+      });
+    },
+  });
+}
+
+export function useUpdateMedicalRecord() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      id,
+      payload,
+    }: {
+      id: string;
+      payload: UpdateMedicalRecordRequest;
+    }) =>
+      apiClient.patch('/care/medical-records/{id}', {
+        pathParams: { id } as ApiPathParams<'/care/medical-records/{id}', 'patch'>,
+        body: payload,
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: medicalRecordKeys.lists(),
+        refetchType: 'all',
+      });
+      notifications.show({
+        title: '医療記録を更新しました',
+        message: '医療記録が正常に更新されました。',
+        color: 'teal',
+      });
+    },
+    onError: (error: Error) => {
+      notifications.show({
+        title: '医療記録の更新に失敗しました',
+        message: error.message ?? '時間をおいて再度お試しください。',
+        color: 'red',
+      });
+    },
+  });
+}
+
+export function useDeleteMedicalRecord() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) =>
+      apiClient.delete('/care/medical-records/{id}', {
+        pathParams: { id } as ApiPathParams<'/care/medical-records/{id}', 'delete'>,
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: medicalRecordKeys.lists(),
+        refetchType: 'all',
+      });
+      notifications.show({
+        title: '医療記録を削除しました',
+        message: '医療記録が正常に削除されました。',
+        color: 'teal',
+      });
+    },
+    onError: (error: Error) => {
+      notifications.show({
+        title: '医療記録の削除に失敗しました',
         message: error.message ?? '時間をおいて再度お試しください。',
         color: 'red',
       });

--- a/frontend/src/lib/api/hooks/use-care.ts
+++ b/frontend/src/lib/api/hooks/use-care.ts
@@ -309,6 +309,33 @@ export function useDeleteCareSchedule() {
   });
 }
 
+export function useUpdateCareScheduleStatus() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, status }: { id: string; status: CareScheduleStatus }) =>
+      apiClient.patch('/care/schedules/{id}/status', {
+        pathParams: { id } as ApiPathParams<'/care/schedules/{id}/status', 'patch'>,
+        body: { status },
+      }),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: careScheduleKeys.lists() });
+      notifications.show({
+        title: 'ステータスを変更しました',
+        message: variables.status === 'CANCELLED' ? '予定を無効にしました。' : '予定を有効にしました。',
+        color: 'teal',
+      });
+    },
+    onError: (error: Error) => {
+      notifications.show({
+        title: 'ステータス変更に失敗しました',
+        message: error.message ?? '時間をおいて再度お試しください。',
+        color: 'red',
+      });
+    },
+  });
+}
+
 export function useCompleteCareSchedule() {
   const queryClient = useQueryClient();
 

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
       "tmp": ">=0.2.3",
       "validator": "13.15.26",
       "defu": ">=6.1.5",
-      "path-to-regexp": "0.1.13",
+      "express>path-to-regexp": "0.1.13",
       "effect": ">=3.20.0"
     },
     "ignoredBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,7 +34,7 @@ overrides:
   tmp: '>=0.2.3'
   validator: 13.15.26
   defu: '>=6.1.5'
-  path-to-regexp: 0.1.13
+  express>path-to-regexp: 0.1.13
   effect: '>=3.20.0'
 
 importers:
@@ -5944,6 +5944,9 @@ packages:
   path-to-regexp@0.1.13:
     resolution: {integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==}
 
+  path-to-regexp@3.3.0:
+    resolution: {integrity: sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==}
+
   path-type@3.0.0:
     resolution: {integrity: sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==}
     engines: {node: '>=4'}
@@ -8473,7 +8476,7 @@ snapshots:
       '@nuxtjs/opencollective': 0.3.2
       fast-safe-stringify: 2.1.1
       iterare: 1.2.1
-      path-to-regexp: 0.1.13
+      path-to-regexp: 3.3.0
       reflect-metadata: 0.2.2
       rxjs: 7.8.2
       tslib: 2.8.1
@@ -8564,7 +8567,7 @@ snapshots:
       '@nestjs/mapped-types': 2.0.5(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)
       js-yaml: 4.1.1
       lodash: 4.18.1
-      path-to-regexp: 0.1.13
+      path-to-regexp: 3.3.0
       reflect-metadata: 0.2.2
       swagger-ui-dist: 5.17.14
     optionalDependencies:
@@ -13728,6 +13731,8 @@ snapshots:
       minipass: 7.1.3
 
   path-to-regexp@0.1.13: {}
+
+  path-to-regexp@3.3.0: {}
 
   path-type@3.0.0:
     dependencies:


### PR DESCRIPTION
## 概要

検証レポート（#225 / `docs/production-validation-report-2026-06.md`）で確定した不具合の修正です。各修正は隔離環境で実際にアプリを動かして動作確認済みです。

## 修正内容（ロードマップ順）

### C-1: 開発環境でバックエンドが起動不能
- pnpm overrides の `path-to-regexp` グローバル固定を `express` 配下にスコープ（@nestjs/swagger が要求する v3 系が正しく解決され、Swagger 生成時の silent crash が解消）
- Swagger 生成を try-catch で保護、起動失敗時は console.error にも出力して必ず可視化

### C-5 / H-4: 既存データの修正・削除を可能に
- 医療記録の詳細取得・更新・削除 API（`GET/PATCH/DELETE /care/medical-records/:id`）+ フロントフック
- 卒業記録の更新 API（`PATCH /graduations/:id`）

### C-2: タグ自動運用の開通（3種別すべて動作確認済み）
- AGE_THRESHOLD: UI保存形式の config を cron が解釈できるよう対応 + 該当ルールのみ実行
- TAG_ASSIGNED: イベント発火を実装（手動付与時のみ。自動化由来は発火せず無限ループ防止）
- PAGE_ACTION: 猫の新規登録/更新・子猫登録・ケア完了・配種スケジュール作成・妊娠確認でイベント発火
- 「今すぐ実行」を実データ対象の即時適用に変更（従来はダミーID対象で常に0件）

### C-3: 関連データを持つ猫の削除（確認済みポリシーで実装）
- ケア履歴・体重・タグ・ギャラリーは削除 / **医療記録・繁殖履歴は残してリンク切断 + 名前スナップショット** / 子猫の親参照もテキスト化
- Prisma migration `cat_deletion_snapshots` 追加

### C-4 / H-1: 交配管理ページ
- 配種スケジュールを実装済みサーバーAPIに配線（localStorage のみ→DB永続化）
- 空実装だった出産情報の「詳細登録」を実装（登録後に子猫管理モーダルで詳細編集）

### H-2 / H-3 / H-6 / H-8 / M-1 / M-5
- NGペアルールをバックエンドで強制（日本語400 + `force` で強行可、フロント確認ダイアログと連動）
- ケアスケジュールの有効/無効スイッチを実装（`PATCH /care/schedules/:id/status` 新設）
- テナント未所属ユーザーの tag-color-defaults 常時400を解消
- スタッフ重複メール 500→409 日本語化（復元案内付き）
- `GET /cats/genders` ルート順序修正、ギャラリー DTO の `@IsEnum(配列)` 誤用修正

## 品質ゲート

- backend lint ✅ / frontend lint ✅（root lint の失敗は既存の `tools/gemini-drive-mcp` 由来で本PRの範囲外）
- backend build ✅ / frontend build ✅
- backend unit 310件 ✅ / frontend unit 27件 ✅
- backend e2e 回帰（cats / care-and-tags / care-tags / breeding-ng-rules）✅
- 各修正は実環境での機能検証スクリプトで動作確認（NG強制・タグ自動付与・猫削除のスナップショット保持等すべて✅）

## 注意事項

- `pnpm-lock.yaml` の変更は override スコープ修正に伴う正規の再生成です
- DBスキーマ変更あり: デプロイ時に `prisma migrate deploy` が必要です（nullable化 + 列追加のみで破壊的変更なし）
- `openapi.json` / `generated/schema.ts` は公式スクリプトで再生成（従来コミットが古く、差分が大きく見えます）

https://claude.ai/code/session_01LBnxBEBnyakawBoac6G78P

---
_Generated by [Claude Code](https://claude.ai/code/session_01LBnxBEBnyakawBoac6G78P)_