### PR TITLE
feat(auth): 権限システム Phase 2（全機能適用）+ error境界補完 + e2e全スイートgreen化

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -20,7 +20,7 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "sh -c 'if [ -f ./.env.test ]; then dotenv -e ./.env.test -- prisma migrate reset --force --schema ./prisma/schema.prisma; else prisma migrate reset --force --schema ./prisma/schema.prisma; fi && for file in test/*.e2e-spec.ts; do echo \"Running $file\"; npx jest \"$file\" --config ./test/jest-e2e.json --runInBand --forceExit; done'",
+    "test:e2e": "sh -c 'if [ -f ./.env.test ]; then dotenv -e ./.env.test -- prisma migrate reset --force --schema ./prisma/schema.prisma; else prisma migrate reset --force --schema ./prisma/schema.prisma; fi && for file in test/*.e2e-spec.ts; do echo \"Running $file\"; npx jest \"$file\" --config ./test/jest-e2e.json --runInBand --forceExit || exit 1; done'",
     "test:e2e:cov": "jest --config ./test/jest-e2e.json --runInBand --coverage",
     "type-check": "tsc --noEmit",
     "swagger:gen": "dotenv -e ./.env -- ts-node -r tsconfig-paths/register src/scripts/generate-swagger.ts",
@@ -157,5 +157,8 @@
         "statements": 70
       }
     }
+  },
+  "prisma": {
+    "seed": "ts-node src/prisma/seed.ts"
   }
 }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -18,6 +18,7 @@ import { PrismaService } from "../prisma/prisma.service";
 
 import { LoginAttemptService, LoginAttemptData } from "./login-attempt.service";
 import { PasswordService } from "./password.service";
+import { ROLE_PRESETS } from "./permissions";
 
 type ValidatedUser = {
   id: string;
@@ -263,6 +264,8 @@ export class AuthService {
       data: {
         email,
         role: UserRole.USER,
+        // 自己登録ユーザーにも招待ユーザーと同じロールプリセット権限を付与する
+        permissions: ROLE_PRESETS[UserRole.USER],
         isActive: true,
         // clerkId は nullable、必要時のみ設定
         clerkId: `local_${randomUUID()}`,

--- a/backend/src/breeding/breeding.controller.ts
+++ b/backend/src/breeding/breeding.controller.ts
@@ -20,6 +20,9 @@ import {
 import type { RequestUser } from "../auth/auth.types";
 import { GetUser } from "../auth/get-user.decorator";
 import { JwtAuthGuard } from "../auth/jwt-auth.guard";
+import { PERMISSIONS } from '../auth/permissions';
+import { PermissionsGuard } from '../auth/permissions.guard';
+import { RequirePermissions } from '../auth/require-permissions.decorator';
 
 
 import { BreedingService } from "./breeding.service";
@@ -49,7 +52,7 @@ export class BreedingController {
   constructor(private readonly breedingService: BreedingService) {}
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Get()
   @ApiOperation({ summary: "交配記録一覧の取得" })
   @ApiResponse({ status: HttpStatus.OK })
@@ -58,8 +61,9 @@ export class BreedingController {
   }
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Post()
+  @RequirePermissions(PERMISSIONS.BREEDING_WRITE)
   @ApiOperation({ summary: "交配記録の新規作成" })
   @ApiResponse({ status: HttpStatus.CREATED })
   create(
@@ -75,7 +79,7 @@ export class BreedingController {
   // matching those static paths as an ":id" and returning 404.
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Get("ng-rules")
   @ApiOperation({ summary: "NGペアルール一覧の取得" })
   @ApiResponse({ status: HttpStatus.OK })
@@ -84,8 +88,9 @@ export class BreedingController {
   }
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Post("ng-rules")
+  @RequirePermissions(PERMISSIONS.BREEDING_WRITE)
   @ApiOperation({ summary: "NGペアルールの作成" })
   @ApiResponse({ status: HttpStatus.CREATED })
   createNgRule(@Body() dto: CreateBreedingNgRuleDto) {
@@ -93,8 +98,9 @@ export class BreedingController {
   }
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Patch("ng-rules/:id")
+  @RequirePermissions(PERMISSIONS.BREEDING_WRITE)
   @ApiOperation({ summary: "NGペアルールの更新" })
   @ApiResponse({ status: HttpStatus.OK })
   @ApiParam({ name: "id" })
@@ -103,8 +109,9 @@ export class BreedingController {
   }
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Delete("ng-rules/:id")
+  @RequirePermissions(PERMISSIONS.BREEDING_WRITE)
   @ApiOperation({ summary: "NGペアルールの削除" })
   @ApiResponse({ status: HttpStatus.OK })
   @ApiParam({ name: "id" })
@@ -115,7 +122,7 @@ export class BreedingController {
   // Pregnancy Check endpoints
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Get("pregnancy-checks")
   @ApiOperation({ summary: "妊娠チェック一覧の取得" })
   @ApiResponse({ status: HttpStatus.OK })
@@ -124,8 +131,9 @@ export class BreedingController {
   }
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Post("pregnancy-checks")
+  @RequirePermissions(PERMISSIONS.BREEDING_WRITE)
   @ApiOperation({ summary: "妊娠チェックの新規作成" })
   @ApiResponse({ status: HttpStatus.CREATED })
   createPregnancyCheck(
@@ -136,8 +144,9 @@ export class BreedingController {
   }
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Patch("pregnancy-checks/:id")
+  @RequirePermissions(PERMISSIONS.BREEDING_WRITE)
   @ApiOperation({ summary: "妊娠チェックの更新" })
   @ApiResponse({ status: HttpStatus.OK })
   @ApiParam({ name: "id" })
@@ -146,8 +155,9 @@ export class BreedingController {
   }
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Delete("pregnancy-checks/:id")
+  @RequirePermissions(PERMISSIONS.BREEDING_WRITE)
   @ApiOperation({ summary: "妊娠チェックの削除" })
   @ApiResponse({ status: HttpStatus.OK })
   @ApiParam({ name: "id" })
@@ -157,7 +167,7 @@ export class BreedingController {
 
   // Birth Plan endpoints
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Get("birth-plans")
   @ApiOperation({ summary: "出産計画一覧の取得" })
   @ApiResponse({ status: HttpStatus.OK })
@@ -166,8 +176,9 @@ export class BreedingController {
   }
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Post("birth-plans")
+  @RequirePermissions(PERMISSIONS.BREEDING_WRITE)
   @ApiOperation({ summary: "出産計画の新規作成" })
   @ApiResponse({ status: HttpStatus.CREATED })
   createBirthPlan(
@@ -178,8 +189,9 @@ export class BreedingController {
   }
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Patch("birth-plans/:id")
+  @RequirePermissions(PERMISSIONS.BREEDING_WRITE)
   @ApiOperation({ summary: "出産計画の更新" })
   @ApiResponse({ status: HttpStatus.OK })
   @ApiParam({ name: "id" })
@@ -188,8 +200,9 @@ export class BreedingController {
   }
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Delete("birth-plans/:id")
+  @RequirePermissions(PERMISSIONS.BREEDING_WRITE)
   @ApiOperation({ summary: "出産計画の削除" })
   @ApiResponse({ status: HttpStatus.OK })
   @ApiParam({ name: "id" })
@@ -200,7 +213,7 @@ export class BreedingController {
   // ========== Kitten Disposition Endpoints ==========
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Get("kitten-dispositions/:birthRecordId")
   @ApiOperation({ summary: "出産記録の子猫処遇一覧取得" })
   @ApiResponse({ status: HttpStatus.OK })
@@ -210,8 +223,9 @@ export class BreedingController {
   }
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Post("kitten-dispositions")
+  @RequirePermissions(PERMISSIONS.BREEDING_WRITE)
   @ApiOperation({ summary: "子猫処遇の登録" })
   @ApiResponse({ status: HttpStatus.CREATED })
   createKittenDisposition(
@@ -222,8 +236,9 @@ export class BreedingController {
   }
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Patch("kitten-dispositions/:id")
+  @RequirePermissions(PERMISSIONS.BREEDING_WRITE)
   @ApiOperation({ summary: "子猫処遇の更新" })
   @ApiResponse({ status: HttpStatus.OK })
   @ApiParam({ name: "id" })
@@ -232,8 +247,9 @@ export class BreedingController {
   }
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Delete("kitten-dispositions/:id")
+  @RequirePermissions(PERMISSIONS.BREEDING_WRITE)
   @ApiOperation({ summary: "子猫処遇の削除" })
   @ApiResponse({ status: HttpStatus.OK })
   @ApiParam({ name: "id" })
@@ -242,8 +258,9 @@ export class BreedingController {
   }
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Post("birth-plans/:id/complete")
+  @RequirePermissions(PERMISSIONS.BREEDING_WRITE)
   @ApiOperation({ summary: "出産記録の完了" })
   @ApiResponse({ status: HttpStatus.OK })
   @ApiParam({ name: "id" })
@@ -254,7 +271,7 @@ export class BreedingController {
   // ========== Breeding Schedule Endpoints ==========
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Get("schedules")
   @ApiOperation({ summary: "交配スケジュール一覧の取得" })
   @ApiResponse({ status: HttpStatus.OK })
@@ -263,8 +280,9 @@ export class BreedingController {
   }
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Post("schedules")
+  @RequirePermissions(PERMISSIONS.BREEDING_WRITE)
   @ApiOperation({ summary: "交配スケジュールの作成" })
   @ApiResponse({ status: HttpStatus.CREATED })
   createBreedingSchedule(
@@ -275,8 +293,9 @@ export class BreedingController {
   }
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Patch("schedules/:id")
+  @RequirePermissions(PERMISSIONS.BREEDING_WRITE)
   @ApiOperation({ summary: "交配スケジュールの更新" })
   @ApiResponse({ status: HttpStatus.OK })
   @ApiParam({ name: "id" })
@@ -285,8 +304,9 @@ export class BreedingController {
   }
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Delete("schedules/:id")
+  @RequirePermissions(PERMISSIONS.BREEDING_WRITE)
   @ApiOperation({ summary: "交配スケジュールの削除" })
   @ApiResponse({ status: HttpStatus.OK })
   @ApiParam({ name: "id" })
@@ -297,7 +317,7 @@ export class BreedingController {
   // ========== Mating Check Endpoints ==========
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Get("schedules/:scheduleId/checks")
   @ApiOperation({ summary: "交配チェック一覧の取得" })
   @ApiResponse({ status: HttpStatus.OK })
@@ -307,8 +327,9 @@ export class BreedingController {
   }
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Post("schedules/:scheduleId/checks")
+  @RequirePermissions(PERMISSIONS.BREEDING_WRITE)
   @ApiOperation({ summary: "交配チェックの追加" })
   @ApiResponse({ status: HttpStatus.CREATED })
   @ApiParam({ name: "scheduleId" })
@@ -320,8 +341,9 @@ export class BreedingController {
   }
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Patch("mating-checks/:id")
+  @RequirePermissions(PERMISSIONS.BREEDING_WRITE)
   @ApiOperation({ summary: "交配チェックの更新" })
   @ApiResponse({ status: HttpStatus.OK })
   @ApiParam({ name: "id" })
@@ -330,8 +352,9 @@ export class BreedingController {
   }
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Delete("mating-checks/:id")
+  @RequirePermissions(PERMISSIONS.BREEDING_WRITE)
   @ApiOperation({ summary: "交配チェックの削除" })
   @ApiResponse({ status: HttpStatus.OK })
   @ApiParam({ name: "id" })
@@ -342,8 +365,9 @@ export class BreedingController {
   // パラメータ化ルートは静的サブパス（pregnancy-checks, birth-plans 等）の
   // 後に配置し、Express が ":id" として誤マッチするのを防ぐ
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Patch(":id")
+  @RequirePermissions(PERMISSIONS.BREEDING_WRITE)
   @ApiOperation({ summary: "交配記録の更新" })
   @ApiResponse({ status: HttpStatus.OK })
   @ApiParam({ name: "id" })
@@ -352,8 +376,9 @@ export class BreedingController {
   }
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Delete(":id")
+  @RequirePermissions(PERMISSIONS.BREEDING_WRITE)
   @ApiOperation({ summary: "交配記録の削除" })
   @ApiResponse({ status: HttpStatus.OK })
   @ApiParam({ name: "id" })

--- a/backend/src/breeds/breeds.controller.ts
+++ b/backend/src/breeds/breeds.controller.ts
@@ -20,13 +20,13 @@ import {
   ApiOkResponse,
   ApiExtraModels,
 } from "@nestjs/swagger";
-import { UserRole } from "@prisma/client";
 
 import type { RequestUser } from "../auth/auth.types";
 import { GetUser } from "../auth/get-user.decorator";
 import { JwtAuthGuard } from "../auth/jwt-auth.guard";
-import { RoleGuard } from "../auth/role.guard";
-import { Roles } from "../auth/roles.decorator";
+import { PERMISSIONS } from '../auth/permissions';
+import { PermissionsGuard } from '../auth/permissions.guard';
+import { RequirePermissions } from '../auth/require-permissions.decorator';
 import { DisplayPreferencesService } from "../display-preferences/display-preferences.service";
 import { MasterDataItemDto } from "../display-preferences/dto/master-data-item.dto";
 
@@ -37,7 +37,7 @@ import { CreateBreedDto, UpdateBreedDto, BreedQueryDto } from "./dto";
 @ApiExtraModels(MasterDataItemDto)
 @ApiTags("Breeds")
 @ApiBearerAuth()
-@UseGuards(JwtAuthGuard)
+@UseGuards(JwtAuthGuard, PermissionsGuard)
 @Controller("breeds")
 export class BreedsController {
   constructor(
@@ -46,8 +46,7 @@ export class BreedsController {
   ) {}
 
   @Post()
-  @UseGuards(RoleGuard)
-  @Roles(UserRole.ADMIN, UserRole.SUPER_ADMIN)
+  @RequirePermissions(PERMISSIONS.SETTINGS_MANAGE)
   @ApiOperation({ summary: "品種データを作成（管理者のみ）" })
   @ApiResponse({
     status: HttpStatus.CREATED,
@@ -142,8 +141,7 @@ export class BreedsController {
   }
 
   @Patch(":id")
-  @UseGuards(RoleGuard)
-  @Roles(UserRole.ADMIN, UserRole.SUPER_ADMIN)
+  @RequirePermissions(PERMISSIONS.SETTINGS_MANAGE)
   @ApiOperation({ summary: "品種データを更新（管理者のみ）" })
   @ApiResponse({
     status: HttpStatus.OK,
@@ -167,8 +165,7 @@ export class BreedsController {
   }
 
   @Delete(":id")
-  @UseGuards(RoleGuard)
-  @Roles(UserRole.ADMIN, UserRole.SUPER_ADMIN)
+  @RequirePermissions(PERMISSIONS.SETTINGS_MANAGE)
   @ApiOperation({ summary: "品種データを削除（管理者のみ）" })
   @ApiResponse({
     status: HttpStatus.OK,

--- a/backend/src/care/care.controller.ts
+++ b/backend/src/care/care.controller.ts
@@ -21,6 +21,9 @@ import {
 import type { RequestUser } from "../auth/auth.types";
 import { GetUser } from "../auth/get-user.decorator";
 import { JwtAuthGuard } from "../auth/jwt-auth.guard";
+import { PERMISSIONS } from '../auth/permissions';
+import { PermissionsGuard } from '../auth/permissions.guard';
+import { RequirePermissions } from '../auth/require-permissions.decorator';
 
 import { CareService } from "./care.service";
 import {
@@ -51,8 +54,9 @@ export class CareController {
   }
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Post("schedules")
+  @RequirePermissions(PERMISSIONS.CARE_WRITE)
   @ApiOperation({ summary: "ケアスケジュールの追加" })
   @ApiResponse({ status: HttpStatus.CREATED, type: CareScheduleResponseDto })
   addSchedule(
@@ -63,9 +67,10 @@ export class CareController {
   }
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Patch("schedules/:id/complete")
   @Put("schedules/:id/complete")
+  @RequirePermissions(PERMISSIONS.CARE_WRITE)
   @ApiOperation({ summary: "ケア完了処理（PATCH/PUT対応）" })
   @ApiResponse({ status: HttpStatus.OK, type: CareCompleteResponseDto })
   @ApiParam({ name: "id" })
@@ -78,8 +83,9 @@ export class CareController {
   }
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Patch("schedules/:id")
+  @RequirePermissions(PERMISSIONS.CARE_WRITE)
   @ApiOperation({ summary: "ケアスケジュールの更新" })
   @ApiResponse({ status: HttpStatus.OK, type: CareScheduleResponseDto })
   @ApiParam({ name: "id", description: "スケジュールID" })
@@ -92,8 +98,9 @@ export class CareController {
   }
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Delete("schedules/:id")
+  @RequirePermissions(PERMISSIONS.CARE_WRITE)
   @ApiOperation({ summary: "ケアスケジュールの削除" })
   @ApiResponse({ status: HttpStatus.OK, description: "削除成功" })
   @ApiParam({ name: "id", description: "スケジュールID" })
@@ -102,8 +109,9 @@ export class CareController {
   }
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Patch("schedules/:id/status")
+  @RequirePermissions(PERMISSIONS.CARE_WRITE)
   @ApiOperation({ summary: "ケアスケジュールのステータス変更（有効/無効）" })
   @ApiParam({ name: "id", description: "スケジュールID" })
   @ApiResponse({ status: HttpStatus.OK, type: CareScheduleResponseDto })
@@ -122,8 +130,9 @@ export class CareController {
   }
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Post("medical-records")
+  @RequirePermissions(PERMISSIONS.MEDICAL_WRITE)
   @ApiOperation({ summary: "医療記録の追加" })
   @ApiResponse({ status: HttpStatus.CREATED, type: MedicalRecordResponseDto })
   addMedicalRecord(
@@ -134,7 +143,7 @@ export class CareController {
   }
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Get("medical-records/:id")
   @ApiOperation({ summary: "医療記録の詳細取得" })
   @ApiParam({ name: "id", description: "医療記録ID" })
@@ -144,8 +153,9 @@ export class CareController {
   }
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Patch("medical-records/:id")
+  @RequirePermissions(PERMISSIONS.MEDICAL_WRITE)
   @ApiOperation({ summary: "医療記録の更新" })
   @ApiParam({ name: "id", description: "医療記録ID" })
   @ApiResponse({ status: HttpStatus.OK, type: MedicalRecordResponseDto })
@@ -157,8 +167,9 @@ export class CareController {
   }
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Delete("medical-records/:id")
+  @RequirePermissions(PERMISSIONS.MEDICAL_WRITE)
   @ApiOperation({ summary: "医療記録の削除" })
   @ApiParam({ name: "id", description: "医療記録ID" })
   @ApiResponse({ status: HttpStatus.OK, description: "削除成功" })

--- a/backend/src/cats/cats.controller.ts
+++ b/backend/src/cats/cats.controller.ts
@@ -25,6 +25,9 @@ import {
 import type { RequestUser } from "../auth/auth.types";
 import { GetUser } from "../auth/get-user.decorator";
 import { JwtAuthGuard } from "../auth/jwt-auth.guard";
+import { PERMISSIONS } from '../auth/permissions';
+import { PermissionsGuard } from '../auth/permissions.guard';
+import { RequirePermissions } from '../auth/require-permissions.decorator';
 
 import { CatsService } from "./cats.service";
 import { GENDER_MASTER } from "./constants/gender";
@@ -41,7 +44,7 @@ import {
 
 @ApiTags("Cats")
 @ApiBearerAuth()
-@UseGuards(JwtAuthGuard)
+@UseGuards(JwtAuthGuard, PermissionsGuard)
 @Controller("cats")
 export class CatsController {
   private readonly logger = new Logger(CatsController.name);
@@ -49,6 +52,7 @@ export class CatsController {
   constructor(private readonly catsService: CatsService) {}
 
   @Post()
+  @RequirePermissions(PERMISSIONS.CATS_WRITE)
   @ApiOperation({ summary: "猫データを作成" })
   @ApiResponse({
     status: HttpStatus.CREATED,
@@ -221,6 +225,7 @@ export class CatsController {
   }
 
   @Patch(":id")
+  @RequirePermissions(PERMISSIONS.CATS_WRITE)
   @ApiOperation({ summary: "猫データを更新" })
   @ApiResponse({
     status: HttpStatus.OK,
@@ -249,6 +254,7 @@ export class CatsController {
   }
 
   @Delete(":id")
+  @RequirePermissions(PERMISSIONS.CATS_WRITE)
   @ApiOperation({ summary: "猫データを削除" })
   @ApiResponse({
     status: HttpStatus.OK,
@@ -319,6 +325,7 @@ export class CatsController {
   }
 
   @Post(":id/weight-records")
+  @RequirePermissions(PERMISSIONS.CATS_WRITE)
   @ApiOperation({ summary: "猫の体重記録を追加" })
   @ApiResponse({
     status: HttpStatus.CREATED,
@@ -362,6 +369,7 @@ export class CatsController {
   }
 
   @Patch("weight-records/:recordId")
+  @RequirePermissions(PERMISSIONS.CATS_WRITE)
   @ApiOperation({ summary: "体重記録を更新" })
   @ApiResponse({
     status: HttpStatus.OK,
@@ -391,6 +399,7 @@ export class CatsController {
   }
 
   @Delete("weight-records/:recordId")
+  @RequirePermissions(PERMISSIONS.CATS_WRITE)
   @ApiOperation({ summary: "体重記録を削除" })
   @ApiResponse({
     status: HttpStatus.OK,
@@ -414,6 +423,7 @@ export class CatsController {
   }
 
   @Post("weight-records/bulk")
+  @RequirePermissions(PERMISSIONS.CATS_WRITE)
   @ApiOperation({ summary: "複数の猫の体重を一括登録" })
   @ApiResponse({
     status: HttpStatus.CREATED,

--- a/backend/src/coat-colors/coat-colors.controller.ts
+++ b/backend/src/coat-colors/coat-colors.controller.ts
@@ -20,13 +20,13 @@ import {
   ApiOkResponse,
   ApiExtraModels,
 } from "@nestjs/swagger";
-import { UserRole } from "@prisma/client";
 
 import type { RequestUser } from "../auth/auth.types";
 import { GetUser } from "../auth/get-user.decorator";
 import { JwtAuthGuard } from "../auth/jwt-auth.guard";
-import { RoleGuard } from "../auth/role.guard";
-import { Roles } from "../auth/roles.decorator";
+import { PERMISSIONS } from '../auth/permissions';
+import { PermissionsGuard } from '../auth/permissions.guard';
+import { RequirePermissions } from '../auth/require-permissions.decorator';
 import { DisplayPreferencesService } from "../display-preferences/display-preferences.service";
 import { MasterDataItemDto } from "../display-preferences/dto/master-data-item.dto";
 
@@ -41,7 +41,7 @@ import {
 @ApiExtraModels(MasterDataItemDto)
 @ApiTags("Coat Colors")
 @ApiBearerAuth()
-@UseGuards(JwtAuthGuard)
+@UseGuards(JwtAuthGuard, PermissionsGuard)
 @Controller("coat-colors")
 export class CoatColorsController {
   constructor(
@@ -50,8 +50,7 @@ export class CoatColorsController {
   ) {}
 
   @Post()
-  @UseGuards(RoleGuard)
-  @Roles(UserRole.ADMIN, UserRole.SUPER_ADMIN)
+  @RequirePermissions(PERMISSIONS.SETTINGS_MANAGE)
   @ApiOperation({ summary: "毛色データを作成（管理者のみ）" })
   @ApiResponse({
     status: HttpStatus.CREATED,
@@ -146,8 +145,7 @@ export class CoatColorsController {
   }
 
   @Patch(":id")
-  @UseGuards(RoleGuard)
-  @Roles(UserRole.ADMIN, UserRole.SUPER_ADMIN)
+  @RequirePermissions(PERMISSIONS.SETTINGS_MANAGE)
   @ApiOperation({ summary: "毛色データを更新（管理者のみ）" })
   @ApiResponse({
     status: HttpStatus.OK,
@@ -174,8 +172,7 @@ export class CoatColorsController {
   }
 
   @Delete(":id")
-  @UseGuards(RoleGuard)
-  @Roles(UserRole.ADMIN, UserRole.SUPER_ADMIN)
+  @RequirePermissions(PERMISSIONS.SETTINGS_MANAGE)
   @ApiOperation({ summary: "毛色データを削除（管理者のみ）" })
   @ApiResponse({
     status: HttpStatus.OK,

--- a/backend/src/display-preferences/display-preferences.controller.ts
+++ b/backend/src/display-preferences/display-preferences.controller.ts
@@ -12,13 +12,16 @@ import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from "@nestjs/swagg
 import type { RequestUser } from "../auth/auth.types";
 import { GetUser } from "../auth/get-user.decorator";
 import { JwtAuthGuard } from "../auth/jwt-auth.guard";
+import { PERMISSIONS } from '../auth/permissions';
+import { PermissionsGuard } from '../auth/permissions.guard';
+import { RequirePermissions } from '../auth/require-permissions.decorator';
 
 import { DisplayPreferencesService } from "./display-preferences.service";
 import { UpdateDisplayPreferenceDto } from "./dto/update-display-preference.dto";
 
 @ApiTags("Display Preferences")
 @ApiBearerAuth()
-@UseGuards(JwtAuthGuard)
+@UseGuards(JwtAuthGuard, PermissionsGuard)
 @Controller("display-preferences")
 export class DisplayPreferencesController {
   constructor(private readonly displayPreferences: DisplayPreferencesService) {}
@@ -35,6 +38,7 @@ export class DisplayPreferencesController {
   }
 
   @Patch("me")
+  @RequirePermissions(PERMISSIONS.SETTINGS_MANAGE)
   @ApiOperation({ summary: "自身の表示設定を更新" })
   @ApiResponse({ status: HttpStatus.OK, description: "表示設定の更新に成功" })
   async updateMine(

--- a/backend/src/export/export.controller.ts
+++ b/backend/src/export/export.controller.ts
@@ -12,18 +12,22 @@ import { Response } from 'express';
 import type { RequestUser } from '../auth/auth.types';
 import { GetUser } from '../auth/get-user.decorator';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { PERMISSIONS } from '../auth/permissions';
+import { PermissionsGuard } from '../auth/permissions.guard';
+import { RequirePermissions } from '../auth/require-permissions.decorator';
 
 import { ExportRequestDto, ExportFormat } from './dto/export-request.dto';
 import { ExportService } from './export.service';
 
 @ApiTags('Export')
 @ApiBearerAuth()
-@UseGuards(JwtAuthGuard)
+@UseGuards(JwtAuthGuard, PermissionsGuard)
 @Controller('export')
 export class ExportController {
   constructor(private readonly exportService: ExportService) {}
 
   @Post()
+  @RequirePermissions(PERMISSIONS.DATA_IMPORT_EXPORT)
   @ApiOperation({ summary: 'データをエクスポート' })
   @ApiResponse({ status: HttpStatus.OK, description: 'エクスポート成功' })
   @ApiResponse({ status: HttpStatus.BAD_REQUEST, description: '無効なリクエスト' })

--- a/backend/src/export/export.controller.ts
+++ b/backend/src/export/export.controller.ts
@@ -4,6 +4,7 @@ import {
   Body,
   UseGuards,
   Res,
+  HttpCode,
   HttpStatus,
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
@@ -28,6 +29,8 @@ export class ExportController {
 
   @Post()
   @RequirePermissions(PERMISSIONS.DATA_IMPORT_EXPORT)
+  // ファイル生成のため作成(201)ではなく 200 を返す
+  @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'データをエクスポート' })
   @ApiResponse({ status: HttpStatus.OK, description: 'エクスポート成功' })
   @ApiResponse({ status: HttpStatus.BAD_REQUEST, description: '無効なリクエスト' })

--- a/backend/src/gallery-upload/gallery-upload.controller.ts
+++ b/backend/src/gallery-upload/gallery-upload.controller.ts
@@ -11,6 +11,9 @@ import {
 import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiBearerAuth } from '@nestjs/swagger';
 
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { PERMISSIONS } from '../auth/permissions';
+import { PermissionsGuard } from '../auth/permissions.guard';
+import { RequirePermissions } from '../auth/require-permissions.decorator';
 
 import { GenerateUploadUrlDto, ConfirmUploadDto } from './dto';
 import { GalleryUploadService } from './gallery-upload.service';
@@ -21,7 +24,7 @@ import { GalleryUploadService } from './gallery-upload.service';
  */
 @ApiTags('Gallery Upload')
 @ApiBearerAuth()
-@UseGuards(JwtAuthGuard)
+@UseGuards(JwtAuthGuard, PermissionsGuard)
 @Controller('gallery/upload')
 export class GalleryUploadController {
   constructor(private readonly uploadService: GalleryUploadService) {}
@@ -30,6 +33,7 @@ export class GalleryUploadController {
    * アップロード用 Signed URL を生成
    */
   @Post('signed-url')
+  @RequirePermissions(PERMISSIONS.GALLERY_WRITE)
   @ApiOperation({
     summary: 'アップロード用Signed URLを生成',
     description: 'クライアントがGCSへ直接アップロードするためのSigned URLを発行します。有効期限は15分です。',
@@ -65,6 +69,7 @@ export class GalleryUploadController {
    * アップロード完了を確認
    */
   @Post('confirm')
+  @RequirePermissions(PERMISSIONS.GALLERY_WRITE)
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
     summary: 'アップロード完了を確認',
@@ -101,6 +106,7 @@ export class GalleryUploadController {
    * アップロード済みファイルを削除
    */
   @Delete(':fileKey')
+  @RequirePermissions(PERMISSIONS.GALLERY_WRITE)
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
     summary: 'アップロード済みファイルを削除',

--- a/backend/src/gallery/gallery.controller.ts
+++ b/backend/src/gallery/gallery.controller.ts
@@ -21,6 +21,9 @@ import {
 } from '@nestjs/swagger';
 
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { PERMISSIONS } from '../auth/permissions';
+import { PermissionsGuard } from '../auth/permissions.guard';
+import { RequirePermissions } from '../auth/require-permissions.decorator';
 
 import {
   CreateGalleryEntryDto,
@@ -37,7 +40,7 @@ import { GalleryService } from './gallery.service';
  */
 @ApiTags('Gallery')
 @ApiBearerAuth()
-@UseGuards(JwtAuthGuard)
+@UseGuards(JwtAuthGuard, PermissionsGuard)
 @Controller('gallery')
 export class GalleryController {
   constructor(private readonly galleryService: GalleryService) {}
@@ -67,6 +70,7 @@ export class GalleryController {
   }
 
   @Post()
+  @RequirePermissions(PERMISSIONS.GALLERY_WRITE)
   @HttpCode(HttpStatus.CREATED)
   @ApiOperation({ summary: 'ギャラリーエントリ作成' })
   @ApiResponse({ status: 201, description: '作成成功' })
@@ -75,6 +79,7 @@ export class GalleryController {
   }
 
   @Put(':id')
+  @RequirePermissions(PERMISSIONS.GALLERY_WRITE)
   @ApiOperation({ summary: 'ギャラリーエントリ更新' })
   @ApiParam({ name: 'id', description: 'エントリID' })
   @ApiResponse({ status: 200, description: '更新成功' })
@@ -87,6 +92,7 @@ export class GalleryController {
   }
 
   @Delete(':id')
+  @RequirePermissions(PERMISSIONS.GALLERY_WRITE)
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'ギャラリーエントリ削除' })
   @ApiParam({ name: 'id', description: 'エントリID' })
@@ -97,6 +103,7 @@ export class GalleryController {
   }
 
   @Post(':id/media')
+  @RequirePermissions(PERMISSIONS.GALLERY_WRITE)
   @HttpCode(HttpStatus.CREATED)
   @ApiOperation({ summary: 'メディア追加' })
   @ApiParam({ name: 'id', description: 'エントリID' })
@@ -106,6 +113,7 @@ export class GalleryController {
   }
 
   @Delete('media/:mediaId')
+  @RequirePermissions(PERMISSIONS.GALLERY_WRITE)
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'メディア削除' })
   @ApiParam({ name: 'mediaId', description: 'メディアID' })
@@ -115,6 +123,7 @@ export class GalleryController {
   }
 
   @Post('bulk')
+  @RequirePermissions(PERMISSIONS.GALLERY_WRITE)
   @HttpCode(HttpStatus.CREATED)
   @ApiOperation({ summary: '一括登録（子育て中タブ用）' })
   @ApiResponse({ status: 201, description: '一括登録成功' })

--- a/backend/src/graduation/graduation.controller.ts
+++ b/backend/src/graduation/graduation.controller.ts
@@ -21,13 +21,16 @@ import {
 } from '@nestjs/swagger';
 
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { PERMISSIONS } from '../auth/permissions';
+import { PermissionsGuard } from '../auth/permissions.guard';
+import { RequirePermissions } from '../auth/require-permissions.decorator';
 
 import { TransferCatDto, UpdateGraduationDto } from './dto';
 import { GraduationService } from './graduation.service';
 
 @ApiTags('Graduation')
 @ApiBearerAuth()
-@UseGuards(JwtAuthGuard)
+@UseGuards(JwtAuthGuard, PermissionsGuard)
 @Controller('graduations')
 export class GraduationController {
   constructor(private readonly graduationService: GraduationService) {}
@@ -36,6 +39,7 @@ export class GraduationController {
    * 猫を譲渡（卒業）する
    */
   @Post('cats/:id/transfer')
+  @RequirePermissions(PERMISSIONS.GRADUATION_WRITE)
   @HttpCode(HttpStatus.CREATED)
   @ApiOperation({ summary: '猫を譲渡（卒業）する' })
   @ApiParam({ name: 'id', description: '猫ID' })
@@ -79,6 +83,7 @@ export class GraduationController {
    * 卒業記録の更新（譲渡日・譲渡先・備考の修正）
    */
   @Patch(':id')
+  @RequirePermissions(PERMISSIONS.GRADUATION_WRITE)
   @ApiOperation({ summary: '卒業記録の更新' })
   @ApiParam({ name: 'id', description: '卒業ID' })
   @ApiResponse({ status: 200, description: '更新成功' })
@@ -94,6 +99,7 @@ export class GraduationController {
    * 卒業取り消し（緊急時用）
    */
   @Delete(':id')
+  @RequirePermissions(PERMISSIONS.GRADUATION_WRITE)
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: '卒業取り消し（緊急時用）' })
   @ApiParam({ name: 'id', description: '卒業ID' })

--- a/backend/src/import/import.controller.ts
+++ b/backend/src/import/import.controller.ts
@@ -20,6 +20,9 @@ import {
 import type { RequestUser } from '../auth/auth.types';
 import { GetUser } from '../auth/get-user.decorator';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { PERMISSIONS } from '../auth/permissions';
+import { PermissionsGuard } from '../auth/permissions.guard';
+import { RequirePermissions } from '../auth/require-permissions.decorator';
 
 import { ImportResultDto, ImportPreviewDto } from './dto/import-response.dto';
 import { ImportService } from './import.service';
@@ -40,7 +43,7 @@ interface UploadedFile {
  */
 @ApiTags('Import')
 @ApiBearerAuth()
-@UseGuards(JwtAuthGuard)
+@UseGuards(JwtAuthGuard, PermissionsGuard)
 @Controller('import')
 export class ImportController {
   constructor(private readonly importService: ImportService) {}
@@ -51,6 +54,7 @@ export class ImportController {
    * ファイルをアップロードして、データの内容をプレビューします
    */
   @Post('preview')
+  @RequirePermissions(PERMISSIONS.DATA_IMPORT_EXPORT)
   @UseInterceptors(FileInterceptor('file'))
   @ApiOperation({ summary: 'インポートファイルのプレビュー' })
   @ApiConsumes('multipart/form-data')
@@ -98,6 +102,7 @@ export class ImportController {
    * CSV ファイルから猫データを一括登録します
    */
   @Post('cats')
+  @RequirePermissions(PERMISSIONS.DATA_IMPORT_EXPORT)
   @UseInterceptors(FileInterceptor('file'))
   @ApiOperation({ summary: '猫データのインポート' })
   @ApiConsumes('multipart/form-data')
@@ -152,6 +157,7 @@ export class ImportController {
    * CSV ファイルから血統書データを一括登録します
    */
   @Post('pedigrees')
+  @RequirePermissions(PERMISSIONS.DATA_IMPORT_EXPORT)
   @UseInterceptors(FileInterceptor('file'))
   @ApiOperation({ summary: '血統書データのインポート' })
   @ApiConsumes('multipart/form-data')
@@ -199,6 +205,7 @@ export class ImportController {
    * CSV ファイルからタグデータを一括登録します
    */
   @Post('tags')
+  @RequirePermissions(PERMISSIONS.DATA_IMPORT_EXPORT)
   @UseInterceptors(FileInterceptor('file'))
   @ApiOperation({ summary: 'タグデータのインポート' })
   @ApiConsumes('multipart/form-data')

--- a/backend/src/pedigree/pedigree.controller.ts
+++ b/backend/src/pedigree/pedigree.controller.ts
@@ -20,12 +20,12 @@ import {
   ApiQuery,
   ApiBearerAuth,
 } from "@nestjs/swagger";
-import { UserRole } from "@prisma/client";
 import { Response } from 'express';
 
 import { JwtAuthGuard } from "../auth/jwt-auth.guard";
-import { RoleGuard } from "../auth/role.guard";
-import { Roles } from "../auth/roles.decorator";
+import { PERMISSIONS } from '../auth/permissions';
+import { PermissionsGuard } from '../auth/permissions.guard';
+import { RequirePermissions } from '../auth/require-permissions.decorator';
 
 import { CreatePedigreeDto, UpdatePedigreeDto, PedigreeQueryDto } from "./dto";
 import { PedigreePdfService } from "./pdf/pedigree-pdf.service";
@@ -35,7 +35,7 @@ import { PedigreeService } from "./pedigree.service";
 
 @ApiTags("Pedigrees")
 @ApiBearerAuth()
-@UseGuards(JwtAuthGuard)
+@UseGuards(JwtAuthGuard, PermissionsGuard)
 @Controller("pedigrees")
 export class PedigreeController {
   constructor(
@@ -45,8 +45,7 @@ export class PedigreeController {
   ) {}
 
   @Post()
-  @UseGuards(RoleGuard)
-  @Roles(UserRole.ADMIN, UserRole.SUPER_ADMIN)
+  @RequirePermissions(PERMISSIONS.PEDIGREE_WRITE)
   @ApiOperation({ summary: "血統書データを作成（管理者のみ）" })
   @ApiResponse({
     status: HttpStatus.CREATED,
@@ -120,6 +119,7 @@ export class PedigreeController {
   }
 
   @Patch("print-settings")
+  @RequirePermissions(PERMISSIONS.PEDIGREE_WRITE)
   @ApiOperation({ summary: "印刷設定を更新" })
   @ApiResponse({ status: HttpStatus.OK, description: "更新後の印刷設定" })
   @ApiResponse({ status: HttpStatus.BAD_REQUEST, description: "無効な設定データです" })
@@ -132,6 +132,7 @@ export class PedigreeController {
   }
 
   @Post("print-settings/reset")
+  @RequirePermissions(PERMISSIONS.PEDIGREE_WRITE)
   @ApiOperation({ summary: "印刷設定をデフォルトにリセット" })
   @ApiResponse({ status: HttpStatus.OK, description: "リセット後の印刷設定" })
   async resetPrintSettings() {
@@ -248,8 +249,7 @@ export class PedigreeController {
   }
 
   @Patch(":id")
-  @UseGuards(RoleGuard)
-  @Roles(UserRole.ADMIN, UserRole.SUPER_ADMIN)
+  @RequirePermissions(PERMISSIONS.PEDIGREE_WRITE)
   @ApiOperation({ summary: "血統書データを更新（管理者のみ）" })
   @ApiResponse({
     status: HttpStatus.OK,
@@ -276,8 +276,7 @@ export class PedigreeController {
   }
 
   @Delete(":id")
-  @UseGuards(RoleGuard)
-  @Roles(UserRole.ADMIN, UserRole.SUPER_ADMIN)
+  @RequirePermissions(PERMISSIONS.PEDIGREE_WRITE)
   @ApiOperation({ summary: "血統書データを削除（管理者のみ）" })
   @ApiResponse({
     status: HttpStatus.OK,

--- a/backend/src/print-templates/print-templates.controller.ts
+++ b/backend/src/print-templates/print-templates.controller.ts
@@ -14,6 +14,9 @@ import {
 import { ApiBearerAuth } from '@nestjs/swagger';
 
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { PERMISSIONS } from '../auth/permissions';
+import { PermissionsGuard } from '../auth/permissions.guard';
+import { RequirePermissions } from '../auth/require-permissions.decorator';
 
 import {
   CreatePrintTemplateDto,
@@ -26,7 +29,7 @@ import {
 import { PrintTemplatesService } from './print-templates.service';
 
 @ApiBearerAuth()
-@UseGuards(JwtAuthGuard)
+@UseGuards(JwtAuthGuard, PermissionsGuard)
 @Controller('print-templates')
 export class PrintTemplatesController {
   constructor(private readonly service: PrintTemplatesService) { }
@@ -66,6 +69,7 @@ export class PrintTemplatesController {
    * POST /api/v1/print-templates/categories
    */
   @Post('categories')
+  @RequirePermissions(PERMISSIONS.SETTINGS_MANAGE)
   async createCategory(@Body() dto: CreatePrintDocCategoryDto) {
     const category = await this.service.createCategory(dto);
     return {
@@ -79,6 +83,7 @@ export class PrintTemplatesController {
    * PATCH /api/v1/print-templates/categories/:id
    */
   @Patch('categories/:id')
+  @RequirePermissions(PERMISSIONS.SETTINGS_MANAGE)
   async updateCategory(
     @Param('id') id: string,
     @Body() dto: UpdatePrintDocCategoryDto,
@@ -95,6 +100,7 @@ export class PrintTemplatesController {
    * DELETE /api/v1/print-templates/categories/:id
    */
   @Delete('categories/:id')
+  @RequirePermissions(PERMISSIONS.SETTINGS_MANAGE)
   @HttpCode(HttpStatus.NO_CONTENT)
   async removeCategory(@Param('id') id: string) {
     await this.service.removeCategory(id);
@@ -151,6 +157,7 @@ export class PrintTemplatesController {
    * POST /api/v1/print-templates
    */
   @Post()
+  @RequirePermissions(PERMISSIONS.SETTINGS_MANAGE)
   async create(@Body() dto: CreatePrintTemplateDto) {
     const template = await this.service.create(dto, dto.tenantId);
     return {
@@ -164,6 +171,7 @@ export class PrintTemplatesController {
    * POST /api/v1/print-templates/:id/duplicate
    */
   @Post(':id/duplicate')
+  @RequirePermissions(PERMISSIONS.SETTINGS_MANAGE)
   async duplicate(
     @Param('id') id: string,
     @Body() dto: DuplicatePrintTemplateDto,
@@ -180,6 +188,7 @@ export class PrintTemplatesController {
    * PATCH /api/v1/print-templates/:id
    */
   @Patch(':id')
+  @RequirePermissions(PERMISSIONS.SETTINGS_MANAGE)
   async update(
     @Param('id') id: string,
     @Body() dto: UpdatePrintTemplateDto,
@@ -196,6 +205,7 @@ export class PrintTemplatesController {
    * DELETE /api/v1/print-templates/:id
    */
   @Delete(':id')
+  @RequirePermissions(PERMISSIONS.SETTINGS_MANAGE)
   @HttpCode(HttpStatus.NO_CONTENT)
   async remove(@Param('id') id: string) {
     await this.service.remove(id);

--- a/backend/src/shift/shift.controller.ts
+++ b/backend/src/shift/shift.controller.ts
@@ -14,6 +14,9 @@ import {
 import { ApiBearerAuth } from '@nestjs/swagger';
 
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { PERMISSIONS } from '../auth/permissions';
+import { PermissionsGuard } from '../auth/permissions.guard';
+import { RequirePermissions } from '../auth/require-permissions.decorator';
 import { ApiResponse } from '../common/dto/api-response.dto';
 import { ShiftResponseDto, CalendarShiftEvent } from '../common/types/shift.types';
 
@@ -23,7 +26,7 @@ import { UpdateShiftDto } from './dto/update-shift.dto';
 import { ShiftService } from './shift.service';
 
 @ApiBearerAuth()
-@UseGuards(JwtAuthGuard)
+@UseGuards(JwtAuthGuard, PermissionsGuard)
 @Controller('shifts')
 export class ShiftController {
   constructor(private readonly shiftService: ShiftService) {}
@@ -32,6 +35,7 @@ export class ShiftController {
    * シフトを新規作成
    */
   @Post()
+  @RequirePermissions(PERMISSIONS.STAFF_MANAGE)
   @HttpCode(HttpStatus.CREATED)
   async create(@Body() createShiftDto: CreateShiftDto): Promise<ApiResponse<ShiftResponseDto>> {
     const shift = await this.shiftService.create(createShiftDto);
@@ -71,6 +75,7 @@ export class ShiftController {
    * シフト情報を更新
    */
   @Patch(':id')
+  @RequirePermissions(PERMISSIONS.STAFF_MANAGE)
   async update(
     @Param('id') id: string,
     @Body() updateShiftDto: UpdateShiftDto,
@@ -83,6 +88,7 @@ export class ShiftController {
    * シフトを削除
    */
   @Delete(':id')
+  @RequirePermissions(PERMISSIONS.STAFF_MANAGE)
   @HttpCode(HttpStatus.OK)
   async remove(@Param('id') id: string): Promise<ApiResponse<{ id: string }>> {
     await this.shiftService.remove(id);

--- a/backend/src/staff/staff.controller.ts
+++ b/backend/src/staff/staff.controller.ts
@@ -13,6 +13,9 @@ import {
 import { ApiBearerAuth } from '@nestjs/swagger';
 
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { PERMISSIONS } from '../auth/permissions';
+import { PermissionsGuard } from '../auth/permissions.guard';
+import { RequirePermissions } from '../auth/require-permissions.decorator';
 import { ApiResponse } from '../common/dto/api-response.dto';
 import { StaffResponseDto, StaffListResponseDto } from '../common/types/staff.types';
 
@@ -21,7 +24,7 @@ import { UpdateStaffDto } from './dto/update-staff.dto';
 import { StaffService } from './staff.service';
 
 @ApiBearerAuth()
-@UseGuards(JwtAuthGuard)
+@UseGuards(JwtAuthGuard, PermissionsGuard)
 @Controller('staff')
 export class StaffController {
   constructor(private readonly staffService: StaffService) {}
@@ -30,6 +33,7 @@ export class StaffController {
    * スタッフを新規作成
    */
   @Post()
+  @RequirePermissions(PERMISSIONS.STAFF_MANAGE)
   @HttpCode(HttpStatus.CREATED)
   async create(@Body() createStaffDto: CreateStaffDto): Promise<ApiResponse<StaffResponseDto>> {
     const staff = await this.staffService.create(createStaffDto);
@@ -58,6 +62,7 @@ export class StaffController {
    * スタッフ情報を更新
    */
   @Patch(':id')
+  @RequirePermissions(PERMISSIONS.STAFF_MANAGE)
   async update(
     @Param('id') id: string,
     @Body() updateStaffDto: UpdateStaffDto,
@@ -70,6 +75,7 @@ export class StaffController {
    * スタッフを削除（論理削除）
    */
   @Delete(':id')
+  @RequirePermissions(PERMISSIONS.STAFF_MANAGE)
   @HttpCode(HttpStatus.OK)
   async remove(@Param('id') id: string): Promise<ApiResponse<StaffResponseDto>> {
     const staff = await this.staffService.remove(id);
@@ -80,6 +86,7 @@ export class StaffController {
    * 削除したスタッフを復元
    */
   @Patch(':id/restore')
+  @RequirePermissions(PERMISSIONS.STAFF_MANAGE)
   async restore(@Param('id') id: string): Promise<ApiResponse<StaffResponseDto>> {
     const staff = await this.staffService.restore(id);
     return ApiResponse.success(staff);

--- a/backend/src/tags/tag-automation.controller.ts
+++ b/backend/src/tags/tag-automation.controller.ts
@@ -22,6 +22,9 @@ import {
 import { TagAutomationEventType, TagAutomationRunStatus, TagAutomationTriggerType } from "@prisma/client";
 
 import { JwtAuthGuard } from "../auth/jwt-auth.guard";
+import { PERMISSIONS } from '../auth/permissions';
+import { PermissionsGuard } from '../auth/permissions.guard';
+import { RequirePermissions } from '../auth/require-permissions.decorator';
 
 import { CreateTagAutomationRuleDto, UpdateTagAutomationRuleDto } from "./dto";
 import { TagAutomationExecutionService } from "./tag-automation-execution.service";
@@ -29,7 +32,7 @@ import { TagAutomationService } from "./tag-automation.service";
 
 @ApiTags("Tag Automation")
 @Controller("tags/automation")
-@UseGuards(JwtAuthGuard)
+@UseGuards(JwtAuthGuard, PermissionsGuard)
 @ApiBearerAuth()
 export class TagAutomationController {
   constructor(
@@ -112,6 +115,7 @@ export class TagAutomationController {
   }
 
   @Post("rules")
+  @RequirePermissions(PERMISSIONS.TAGS_MANAGE)
   @ApiOperation({ summary: "自動化ルールの作成" })
   @ApiResponse({ status: HttpStatus.CREATED, description: "ルールを作成しました" })
   @ApiResponse({ status: HttpStatus.BAD_REQUEST, description: "入力エラー" })
@@ -120,6 +124,7 @@ export class TagAutomationController {
   }
 
   @Patch("rules/:id")
+  @RequirePermissions(PERMISSIONS.TAGS_MANAGE)
   @ApiOperation({ summary: "自動化ルールの更新" })
   @ApiResponse({ status: HttpStatus.OK, description: "ルールを更新しました" })
   @ApiResponse({ status: HttpStatus.NOT_FOUND, description: "ルールが見つかりません" })
@@ -129,6 +134,7 @@ export class TagAutomationController {
   }
 
   @Delete("rules/:id")
+  @RequirePermissions(PERMISSIONS.TAGS_MANAGE)
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({ summary: "自動化ルールの削除" })
   @ApiResponse({ status: HttpStatus.NO_CONTENT, description: "ルールを削除しました" })
@@ -175,6 +181,7 @@ export class TagAutomationController {
   }
 
     @Post("rules/:id/execute")
+    @RequirePermissions(PERMISSIONS.TAGS_MANAGE)
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: "ルールを手動実行（実データの対象猫に即時適用）" })
   @ApiParam({ name: "id", description: "ルールID" })

--- a/backend/src/tags/tag-categories.controller.ts
+++ b/backend/src/tags/tag-categories.controller.ts
@@ -14,6 +14,9 @@ import {
 import { ApiBearerAuth, ApiOperation, ApiParam, ApiQuery, ApiResponse, ApiTags } from "@nestjs/swagger";
 
 import { JwtAuthGuard } from "../auth/jwt-auth.guard";
+import { PERMISSIONS } from '../auth/permissions';
+import { PermissionsGuard } from '../auth/permissions.guard';
+import { RequirePermissions } from '../auth/require-permissions.decorator';
 
 import { CreateTagCategoryDto } from "./dto/create-tag-category.dto";
 import { ReorderTagCategoriesDto } from "./dto/reorder-tag-category.dto";
@@ -48,8 +51,9 @@ export class TagCategoriesController {
   }
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Post()
+  @RequirePermissions(PERMISSIONS.TAGS_MANAGE)
   @ApiOperation({ summary: "タグカテゴリの作成" })
   @ApiResponse({ status: HttpStatus.CREATED })
   create(@Body() dto: CreateTagCategoryDto) {
@@ -57,8 +61,9 @@ export class TagCategoriesController {
   }
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Patch("reorder")
+  @RequirePermissions(PERMISSIONS.TAGS_MANAGE)
   @ApiOperation({ summary: "タグカテゴリの並び替え" })
   @ApiResponse({ status: HttpStatus.OK })
   reorder(@Body() dto: ReorderTagCategoriesDto) {
@@ -66,8 +71,9 @@ export class TagCategoriesController {
   }
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Patch(":id")
+  @RequirePermissions(PERMISSIONS.TAGS_MANAGE)
   @ApiOperation({ summary: "タグカテゴリの更新" })
   @ApiResponse({ status: HttpStatus.OK })
   @ApiParam({ name: "id" })
@@ -76,8 +82,9 @@ export class TagCategoriesController {
   }
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Delete(":id")
+  @RequirePermissions(PERMISSIONS.TAGS_MANAGE)
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({ summary: "タグカテゴリの削除" })
   @ApiParam({ name: "id" })

--- a/backend/src/tags/tag-groups.controller.ts
+++ b/backend/src/tags/tag-groups.controller.ts
@@ -12,6 +12,9 @@ import {
 import { ApiBearerAuth, ApiOperation, ApiParam, ApiResponse, ApiTags } from "@nestjs/swagger";
 
 import { JwtAuthGuard } from "../auth/jwt-auth.guard";
+import { PERMISSIONS } from '../auth/permissions';
+import { PermissionsGuard } from '../auth/permissions.guard';
+import { RequirePermissions } from '../auth/require-permissions.decorator';
 
 import { CreateTagGroupDto, ReorderTagGroupDto, UpdateTagGroupDto } from "./dto";
 import { TagGroupsService } from "./tag-groups.service";
@@ -22,8 +25,9 @@ export class TagGroupsController {
   constructor(private readonly tagGroupsService: TagGroupsService) {}
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Post()
+  @RequirePermissions(PERMISSIONS.TAGS_MANAGE)
   @ApiOperation({ summary: "タググループの作成" })
   @ApiResponse({ status: HttpStatus.CREATED })
   create(@Body() dto: CreateTagGroupDto) {
@@ -31,8 +35,9 @@ export class TagGroupsController {
   }
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Patch("reorder")
+  @RequirePermissions(PERMISSIONS.TAGS_MANAGE)
   @ApiOperation({ summary: "タググループの並び替え" })
   @ApiResponse({ status: HttpStatus.OK })
   reorder(@Body() dto: ReorderTagGroupDto) {
@@ -40,8 +45,9 @@ export class TagGroupsController {
   }
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Patch(":id")
+  @RequirePermissions(PERMISSIONS.TAGS_MANAGE)
   @ApiOperation({ summary: "タググループの更新" })
   @ApiResponse({ status: HttpStatus.OK })
   @ApiParam({ name: "id" })
@@ -50,8 +56,9 @@ export class TagGroupsController {
   }
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Delete(":id")
+  @RequirePermissions(PERMISSIONS.TAGS_MANAGE)
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({ summary: "タググループの削除" })
   @ApiParam({ name: "id" })

--- a/backend/src/tags/tags.controller.ts
+++ b/backend/src/tags/tags.controller.ts
@@ -21,6 +21,9 @@ import {
 } from "@nestjs/swagger";
 
 import { JwtAuthGuard } from "../auth/jwt-auth.guard";
+import { PERMISSIONS } from '../auth/permissions';
+import { PermissionsGuard } from '../auth/permissions.guard';
+import { RequirePermissions } from '../auth/require-permissions.decorator';
 
 import { AssignTagDto, CreateTagDto, ReorderTagsDto, UpdateTagDto } from "./dto";
 import { TagsService } from "./tags.service";
@@ -50,8 +53,9 @@ export class TagsController {
   }
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Post()
+  @RequirePermissions(PERMISSIONS.TAGS_MANAGE)
   @ApiOperation({ summary: "タグの作成" })
   @ApiResponse({ status: HttpStatus.CREATED })
   create(@Body() dto: CreateTagDto) {
@@ -59,8 +63,9 @@ export class TagsController {
   }
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Patch("reorder")
+  @RequirePermissions(PERMISSIONS.TAGS_MANAGE)
   @ApiOperation({ summary: "タグの並び替え" })
   @ApiResponse({ status: HttpStatus.OK })
   reorder(@Body() dto: ReorderTagsDto) {
@@ -68,8 +73,9 @@ export class TagsController {
   }
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Patch(":id")
+  @RequirePermissions(PERMISSIONS.TAGS_MANAGE)
   @ApiOperation({ summary: "タグの更新" })
   @ApiResponse({ status: HttpStatus.OK })
   @ApiParam({ name: "id" })
@@ -78,8 +84,9 @@ export class TagsController {
   }
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Delete(":id")
+  @RequirePermissions(PERMISSIONS.TAGS_MANAGE)
   @ApiOperation({ summary: "タグの削除" })
   @ApiResponse({ status: HttpStatus.OK })
   @ApiParam({ name: "id" })
@@ -88,8 +95,9 @@ export class TagsController {
   }
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Post("/cats/:id/tags")
+  @RequirePermissions(PERMISSIONS.CATS_WRITE)
   @ApiOperation({ summary: "猫にタグを付与" })
   @ApiResponse({ status: HttpStatus.OK, description: "付与成功（重複時もOK）" })
   @ApiParam({ name: "id" })
@@ -99,8 +107,9 @@ export class TagsController {
   }
 
   @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @Delete("/cats/:id/tags/:tagId")
+  @RequirePermissions(PERMISSIONS.CATS_WRITE)
   @ApiOperation({ summary: "猫からタグを剥奪" })
   @ApiResponse({ status: HttpStatus.OK })
   @ApiParam({ name: "id" })

--- a/backend/test/auth-jwt.e2e-spec.ts
+++ b/backend/test/auth-jwt.e2e-spec.ts
@@ -3,6 +3,7 @@ import { Test } from '@nestjs/testing';
 import request from 'supertest';
 import { AppModule } from '../src/app.module';
 import { JwtService } from '@nestjs/jwt';
+import helmet from 'helmet';
 
 describe('Auth JWT & Rate Limiting (e2e)', () => {
   let app: INestApplication;
@@ -15,6 +16,9 @@ describe('Auth JWT & Rate Limiting (e2e)', () => {
 
     app = moduleRef.createNestApplication();
     app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
+    // 本番（main.ts）と同じセキュリティミドルウェア構成に揃える
+    app.use(helmet());
+    app.enableCors({ origin: true, credentials: true });
     app.setGlobalPrefix('api/v1');
     await app.init();
 

--- a/backend/test/auth-seed-user.e2e-spec.ts
+++ b/backend/test/auth-seed-user.e2e-spec.ts
@@ -1,7 +1,9 @@
-import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { INestApplication } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import request from 'supertest';
 import { AppModule } from '../src/app.module';
+
+import { createTestApp } from './utils/create-test-app';
 
 /**
  * シードユーザーでのログイン確認E2Eテスト
@@ -25,10 +27,8 @@ describe('Auth with Seed User (e2e)', () => {
       imports: [AppModule],
     }).compile();
 
-    app = moduleRef.createNestApplication();
-    app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
-    app.setGlobalPrefix('api/v1');
-    await app.init();
+    // 本番と同じインターセプタ/フィルタ構成（success ラップ等）を適用する
+    app = await createTestApp(moduleRef);
   });
 
   afterAll(async () => {

--- a/backend/test/breeds-coat-colors.e2e-spec.ts
+++ b/backend/test/breeds-coat-colors.e2e-spec.ts
@@ -8,6 +8,8 @@ import { AppModule } from '../src/app.module';
 import { PrismaService } from '../src/prisma/prisma.service';
 import { createTestApp } from './utils/create-test-app';
 
+import { ROLE_PRESETS } from '../src/auth/permissions';
+
 const httpStatus = {
   ok: 200,
   created: 201,
@@ -68,7 +70,8 @@ describe('Breeds & Coat Colors API (e2e)', () => {
 
     await prisma.user.update({
       where: { email },
-      data: { role: UserRole.ADMIN },
+      // 権限ベース移行に伴い、ロールと併せてプリセット権限（settings:manage 含む）を付与する
+      data: { role: UserRole.ADMIN, permissions: ROLE_PRESETS[UserRole.ADMIN] },
     });
 
     const loginRes = await request(app.getHttpServer()).post('/api/v1/auth/login').send({ email, password });

--- a/backend/test/care-and-tags.e2e-spec.ts
+++ b/backend/test/care-and-tags.e2e-spec.ts
@@ -79,13 +79,11 @@ describe("Care & Tags flows (e2e)", () => {
   });
 
   it("tags: create -> assign -> unassign", async () => {
-    const email = `e2e_${Date.now()}@example.com`;
-    const password = "Secret123!";
-
-    // register & login
-    const registerRes = await request(app.getHttpServer()).post('/api/v1/auth/register').send({ email, password });
-    expect(registerRes.status).toBe(201);
-    const login = await request(app.getHttpServer()).post('/api/v1/auth/login').send({ email, password });
+    // タグ定義の管理には tags:manage 権限が必要なため、シード管理者（SUPER_ADMIN）でログインする
+    const login = await request(app.getHttpServer()).post('/api/v1/auth/login').send({
+      email: process.env.ADMIN_EMAIL ?? 'admin@example.com',
+      password: process.env.ADMIN_PASSWORD ?? 'Passw0rd!',
+    });
     expect(login.status).toBe(201);
     const token = login.body.data.access_token as string;
 

--- a/backend/test/care-tags.e2e-spec.ts
+++ b/backend/test/care-tags.e2e-spec.ts
@@ -32,6 +32,14 @@ describe("Care & Tags flows (e2e)", () => {
     expect(login.status).toBe(201);
     const token = login.body.data.access_token as string;
 
+    // タグ定義の管理には tags:manage 権限が必要なため、シード管理者でログインする
+    const adminLogin = await request(app.getHttpServer()).post("/api/v1/auth/login").send({
+      email: process.env.ADMIN_EMAIL ?? "admin@example.com",
+      password: process.env.ADMIN_PASSWORD ?? "Passw0rd!",
+    });
+    expect(adminLogin.status).toBe(201);
+    const adminToken = adminLogin.body.data.access_token as string;
+
     // create a cat (owned by the registered user)
     const catRes = await request(app.getHttpServer())
       .post("/api/v1/cats")
@@ -53,7 +61,7 @@ describe("Care & Tags flows (e2e)", () => {
     // create a tag category first
     const categoryRes = await request(app.getHttpServer())
       .post("/api/v1/tags/categories")
-      .set("Authorization", `Bearer ${token}`)
+      .set("Authorization", `Bearer ${adminToken}`)
       .send({ name: "Test Category", key: `test_category_${Date.now()}` });
     expect(categoryRes.status).toBe(201);
     const categoryId = categoryRes.body.data.id as string;
@@ -61,7 +69,7 @@ describe("Care & Tags flows (e2e)", () => {
     // create a tag group
     const groupRes = await request(app.getHttpServer())
       .post("/api/v1/tags/groups")
-      .set("Authorization", `Bearer ${token}`)
+      .set("Authorization", `Bearer ${adminToken}`)
       .send({ categoryId, name: "Test Group" });
     expect(groupRes.status).toBe(201);
     const groupId = groupRes.body.data.id as string;
@@ -69,7 +77,7 @@ describe("Care & Tags flows (e2e)", () => {
     // create a tag (auth required)
     const tagRes = await request(app.getHttpServer())
       .post("/api/v1/tags")
-      .set("Authorization", `Bearer ${token}`)
+      .set("Authorization", `Bearer ${adminToken}`)
       .send({ name: `indoor-${Date.now()}`, groupId, color: "#00AA88" });
     expect(tagRes.status).toBe(201);
     const tagId = tagRes.body.data.id as string;

--- a/backend/test/export.e2e-spec.ts
+++ b/backend/test/export.e2e-spec.ts
@@ -15,13 +15,9 @@ describe('Export API (e2e)', () => {
 
     app = await createTestApp(moduleRef);
 
-    const email = `export_test_${Date.now()}@example.com`;
-    const password = 'ExportTest123!';
-
-    const res = await request(app.getHttpServer())
-      .post('/api/v1/auth/register')
-      .send({ email, password });
-    expect(res.status).toBe(201);
+    // data:import_export 権限が必要なため、シード管理者（SUPER_ADMIN）でログインする
+    const email = process.env.ADMIN_EMAIL ?? 'admin@example.com';
+    const password = process.env.ADMIN_PASSWORD ?? 'Passw0rd!';
 
     const loginRes = await request(app.getHttpServer())
       .post('/api/v1/auth/login')

--- a/backend/test/import.e2e-spec.ts
+++ b/backend/test/import.e2e-spec.ts
@@ -18,13 +18,9 @@ describe('Import API (e2e)', () => {
 
     app = await createTestApp(moduleRef);
 
-    const email = `import_test_${Date.now()}@example.com`;
-    const password = 'ImportTest123!';
-
-    const res = await request(app.getHttpServer())
-      .post('/api/v1/auth/register')
-      .send({ email, password });
-    expect(res.status).toBe(201);
+    // data:import_export 権限が必要なため、シード管理者（SUPER_ADMIN）でログインする
+    const email = process.env.ADMIN_EMAIL ?? 'admin@example.com';
+    const password = process.env.ADMIN_PASSWORD ?? 'Passw0rd!';
 
     const loginRes = await request(app.getHttpServer())
       .post('/api/v1/auth/login')

--- a/backend/test/pedigree.e2e-spec.ts
+++ b/backend/test/pedigree.e2e-spec.ts
@@ -12,6 +12,7 @@ import { createTestApp } from './utils/create-test-app';
 const httpStatus = {
   ok: 200,
   created: 201,
+  unauthorized: 401,
   forbidden: 403,
   notFound: 404,
 };
@@ -20,6 +21,7 @@ describe('Pedigree module (integration)', () => {
   let app: INestApplication;
   let prisma: PrismaService;
   let pedigreeService: PedigreeService;
+  let authToken: string;
   const createdPedigreeIds: string[] = [];
   const createdBreedIds: string[] = [];
   const createdCoatColorIds: string[] = [];
@@ -56,6 +58,17 @@ describe('Pedigree module (integration)', () => {
     app = await createTestApp(moduleRef);
     prisma = app.get(PrismaService);
     pedigreeService = app.get(PedigreeService);
+
+    // 血統書APIは認証必須のため、シード管理者（SUPER_ADMIN）でログインする
+    const loginRes = await request(app.getHttpServer())
+      .post('/api/v1/auth/login')
+        .set('Authorization', `Bearer ${authToken}`)
+      .send({
+        email: process.env.ADMIN_EMAIL ?? 'admin@example.com',
+        password: process.env.ADMIN_PASSWORD ?? 'Passw0rd!',
+      });
+    expect(loginRes.status).toBe(201);
+    authToken = loginRes.body.data.access_token;
   });
 
   afterAll(async () => {
@@ -86,6 +99,7 @@ describe('Pedigree module (integration)', () => {
 
       const listRes = await request(app.getHttpServer())
         .get('/api/v1/pedigrees')
+        .set('Authorization', `Bearer ${authToken}`)
         .query({ search: 'Integration' })
         .expect(httpStatus.ok);
 
@@ -101,6 +115,7 @@ describe('Pedigree module (integration)', () => {
 
       const byIdRes = await request(app.getHttpServer())
         .get(`/api/v1/pedigrees/${created.id}`)
+        .set('Authorization', `Bearer ${authToken}`)
         .expect(httpStatus.ok);
 
       expect(byIdRes.body.success).toBe(true);
@@ -109,6 +124,7 @@ describe('Pedigree module (integration)', () => {
 
       const byPedigreeIdRes = await request(app.getHttpServer())
         .get(`/api/v1/pedigrees/pedigree-id/${created.pedigreeId}`)
+        .set('Authorization', `Bearer ${authToken}`)
         .expect(httpStatus.ok);
 
       expect(byPedigreeIdRes.body.success).toBe(true);
@@ -120,6 +136,7 @@ describe('Pedigree module (integration)', () => {
 
       const familyTreeRes = await request(app.getHttpServer())
         .get(`/api/v1/pedigrees/${created.id}/family-tree`)
+        .set('Authorization', `Bearer ${authToken}`)
         .expect(httpStatus.ok);
 
       expect(familyTreeRes.body.success).toBe(true);
@@ -127,6 +144,7 @@ describe('Pedigree module (integration)', () => {
 
       const familyRes = await request(app.getHttpServer())
         .get(`/api/v1/pedigrees/${created.id}/family`)
+        .set('Authorization', `Bearer ${authToken}`)
         .query({ generations: 2 })
         .expect(httpStatus.ok);
 
@@ -146,6 +164,7 @@ describe('Pedigree module (integration)', () => {
 
       const verifyRes = await request(app.getHttpServer())
         .get(`/api/v1/pedigrees/${created.id}`)
+        .set('Authorization', `Bearer ${authToken}`)
         .expect(httpStatus.ok);
 
       expect(verifyRes.body.data.notes).toBe('Updated note for coverage');
@@ -160,6 +179,7 @@ describe('Pedigree module (integration)', () => {
 
       const notFoundRes = await request(app.getHttpServer())
         .get(`/api/v1/pedigrees/${created.id}`)
+        .set('Authorization', `Bearer ${authToken}`)
         .expect(httpStatus.notFound);
 
       expect(notFoundRes.body.success).toBe(false);
@@ -174,14 +194,35 @@ describe('Pedigree module (integration)', () => {
   });
 
   describe('authorization and error handling', () => {
-    it('rejects pedigree creation via HTTP without admin role', async () => {
-      const payload = buildCreateDto({ title: 'Forbidden attempt' });
+    it('rejects pedigree creation via HTTP without authentication', async () => {
+      const payload = buildCreateDto({ title: 'Unauthorized attempt' });
 
       const res = await request(app.getHttpServer())
         .post('/api/v1/pedigrees')
         .send(payload);
-      expect(res.status).toBe(httpStatus.forbidden);
+      expect(res.status).toBe(httpStatus.unauthorized);
+      expect(res.body.success).toBe(false);
+    });
 
+    it('rejects pedigree creation for users without pedigree:write permission', async () => {
+      // 自己登録ユーザー（USERプリセット: pedigree:write なし）で 403 になること
+      const email = `pedigree_user_${Date.now()}@example.com`;
+      const password = 'PedigreeUser123!';
+      await request(app.getHttpServer())
+        .post('/api/v1/auth/register')
+        .send({ email, password })
+        .expect(201);
+      const loginRes = await request(app.getHttpServer())
+        .post('/api/v1/auth/login')
+        .send({ email, password });
+      const userToken = loginRes.body.data.access_token as string;
+
+      const payload = buildCreateDto({ title: 'Forbidden attempt' });
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/pedigrees')
+        .set('Authorization', `Bearer ${userToken}`)
+        .send(payload);
+      expect(res.status).toBe(httpStatus.forbidden);
       expect(res.body.success).toBe(false);
       expect(res.body.error.code).toBe('FORBIDDEN');
     });
@@ -192,6 +233,7 @@ describe('Pedigree module (integration)', () => {
 
       const byIdRes = await request(app.getHttpServer())
         .get(`/api/v1/pedigrees/${missingId}`)
+        .set('Authorization', `Bearer ${authToken}`)
         .expect(httpStatus.notFound);
 
       expect(byIdRes.body.success).toBe(false);
@@ -199,6 +241,7 @@ describe('Pedigree module (integration)', () => {
 
       const byPedigreeIdRes = await request(app.getHttpServer())
         .get(`/api/v1/pedigrees/pedigree-id/${missingPedigreeId}`)
+        .set('Authorization', `Bearer ${authToken}`)
         .expect(httpStatus.notFound);
 
       expect(byPedigreeIdRes.body.success).toBe(false);
@@ -220,18 +263,21 @@ describe('Pedigree module (integration)', () => {
 
       const familyTreeRes = await request(app.getHttpServer())
         .get(`/api/v1/pedigrees/${missingId}/family-tree`)
+        .set('Authorization', `Bearer ${authToken}`)
         .expect(httpStatus.notFound);
 
       expect(familyTreeRes.body.success).toBe(false);
 
       const familyRes = await request(app.getHttpServer())
         .get(`/api/v1/pedigrees/${missingId}/family`)
+        .set('Authorization', `Bearer ${authToken}`)
         .expect(httpStatus.notFound);
 
       expect(familyRes.body.success).toBe(false);
 
       const descendantsRes = await request(app.getHttpServer())
         .get(`/api/v1/pedigrees/${missingId}/descendants`)
+        .set('Authorization', `Bearer ${authToken}`)
         .expect(httpStatus.notFound);
 
       expect(descendantsRes.body.success).toBe(false);
@@ -296,6 +342,7 @@ describe('Pedigree module (integration)', () => {
 
       const listRes = await request(app.getHttpServer())
         .get('/api/v1/pedigrees')
+        .set('Authorization', `Bearer ${authToken}`)
         .query({
           breedId: String(breed.code),
           coatColorId: String(color.code),
@@ -328,6 +375,7 @@ describe('Pedigree module (integration)', () => {
 
       const res = await request(app.getHttpServer())
         .get(`/api/v1/pedigrees/${parent.id}/descendants`)
+        .set('Authorization', `Bearer ${authToken}`)
         .expect(httpStatus.ok);
 
       expect(res.body.success).toBe(true);

--- a/backend/test/utils/create-test-app.ts
+++ b/backend/test/utils/create-test-app.ts
@@ -1,5 +1,6 @@
 import { INestApplication, ValidationPipe } from '@nestjs/common';
 import { TestingModule } from '@nestjs/testing';
+import helmet from 'helmet';
 
 import { TransformResponseInterceptor } from '../../src/common/interceptors/transform-response.interceptor';
 import { PerformanceMonitoringInterceptor } from '../../src/common/interceptors/performance-monitoring.interceptor';
@@ -7,6 +8,10 @@ import { EnhancedGlobalExceptionFilter } from '../../src/common/filters/enhanced
 
 export async function createTestApp(moduleRef: TestingModule): Promise<INestApplication> {
   const app = moduleRef.createNestApplication();
+
+  // 本番（main.ts）と同じセキュリティミドルウェア構成に揃える
+  app.use(helmet());
+  app.enableCors({ origin: true, credentials: true });
 
   app.useGlobalPipes(
     new ValidationPipe({

--- a/docs/permission-system-design.md
+++ b/docs/permission-system-design.md
@@ -1,6 +1,6 @@
 # 権限管理システム設計書（ロール + 個別権限のハイブリッド方式）
 
-**Status:** 承認済み・Phase 1 実装済み（2026-06-11 オーナーレビュー承認）
+**Status:** 承認済み・Phase 1/2 実装済み（2026-06-11 オーナーレビュー承認）
 **作成日:** 2026-06-11
 **関連:** 検証レポート H-5（ADMINロールで /tenants・/users が403になるロール設計の矛盾）
 
@@ -170,7 +170,7 @@ SUPER_ADMIN（サービス運営者）
 | Phase | 内容 | 規模感 |
 |---|---|---|
 | **Phase 1 ✅実装済み** | スキーマ追加 + バックフィル / 権限定数・デコレータ・ガード基盤 / JWTへの権限埋め込み / 招待・編集UIのチェックボックス / **users:manage・tenants:manage の適用**（ユーザー設定ページの403解消） | 中 |
-| **Phase 2** | 書き込み系エンドポイントへ `@RequirePermissions` を段階適用（cats → breeding → care/medical → その他）+ フロントの出し分け | 中〜大（機械的） |
+| **Phase 2 ✅実装済み** | 全19コントローラ・約98の書き込みエンドポイントへ `@RequirePermissions` を適用 + ナビゲーションの権限出し分け（作成専用ページの非表示）。品種・毛色マスタは settings:manage に分類。ページ内ボタン単位の出し分けは漸進対応 | 中〜大（機械的） |
 | **Phase 3** | `@Roles` の撤去、`ADMIN` ロール廃止の検討、権限変更の即時失効対応（必要なら） | 小〜中 |
 
 ### 実施済み（本設計と同時にコミット）
@@ -196,3 +196,11 @@ SUPER_ADMIN（サービス運営者）
 - 実装ファイル: `backend/src/auth/permissions.ts` / `require-permissions.decorator.ts` / `permissions.guard.ts`、`frontend/src/lib/auth/permissions.ts`、`PermissionCheckboxGroup.tsx`
 - migration: `user_permissions`（バックフィル含む）/ `invitation_permissions`
 - 検証済みシナリオ: ADMIN の users:manage なし403（日本語）/ SUPER_ADMIN 全通 / 権限指定付き招待→完了→指定権限でユーザー作成 / 権限外操作403 / 権限の天井（自己変更403・tenants:manage 配布403）
+
+## 13. Phase 2 実装メモ（2026-06-12）
+
+- 全コントローラの書き込み（POST/PATCH/PUT/DELETE）に権限を適用。閲覧（GET）は全ログインユーザーのまま
+- breeds / coat-colors / pedigree の旧 @Roles(ADMIN, SUPER_ADMIN) + RoleGuard を @RequirePermissions に置換
+- /auth/register の自己登録ユーザーにも USER プリセット権限を付与（招待経路と一貫）
+- ナビゲーション: requiredPermission 付きの項目（新規猫登録= cats:write）を権限がない場合に非表示
+- e2e 全14スイートを権限ベース仕様に追従させ green 化（テスト基盤の修正: prisma.seed フック追加・test:e2e の失敗伝播・テストアプリの helmet/CORS 適用）

--- a/frontend/src/app/error.tsx
+++ b/frontend/src/app/error.tsx
@@ -1,0 +1,56 @@
+'use client';
+// 理由: App Router の error boundary はクライアントコンポーネントである必要がある
+
+import { Alert, Button, Center, Stack, Text } from '@mantine/core';
+import { IconAlertTriangle, IconRefresh } from '@tabler/icons-react';
+import { useEffect } from 'react';
+
+/**
+ * ルート共通のエラーバウンダリ
+ *
+ * セグメント内で捕捉されなかったレンダリングエラーを受け止め、
+ * 日本語の案内と再試行ボタンを表示する。
+ */
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    // 調査用にコンソールへ出力（本番では Sentry 等が拾う）
+    console.error('画面の描画でエラーが発生しました:', error);
+  }, [error]);
+
+  return (
+    <Center mih="60vh" p="md">
+      <Stack gap="md" maw={480} w="100%">
+        <Alert
+          icon={<IconAlertTriangle size={20} />}
+          title="エラーが発生しました"
+          color="red"
+          variant="light"
+        >
+          <Text size="sm">
+            画面の表示中に問題が発生しました。再試行しても解決しない場合は、
+            ページを再読み込みするか、時間をおいてからお試しください。
+          </Text>
+          {error.digest && (
+            <Text size="xs" c="dimmed" mt="xs">
+              エラーID: {error.digest}
+            </Text>
+          )}
+        </Alert>
+        <Button
+          leftSection={<IconRefresh size={16} />}
+          onClick={reset}
+          variant="light"
+          data-testid="error-retry-button"
+        >
+          再試行
+        </Button>
+      </Stack>
+    </Center>
+  );
+}

--- a/frontend/src/app/export/loading.tsx
+++ b/frontend/src/app/export/loading.tsx
@@ -1,0 +1,5 @@
+import { PageLoader } from '@/components/PageLoader';
+
+export default function Loading() {
+  return <PageLoader message="エクスポート画面を読み込み中..." />;
+}

--- a/frontend/src/app/global-error.tsx
+++ b/frontend/src/app/global-error.tsx
@@ -1,0 +1,49 @@
+'use client';
+// 理由: App Router の global error boundary はクライアントコンポーネントである必要がある
+
+/**
+ * ルートレイアウト自体が壊れた場合の最終フォールバック
+ *
+ * MantineProvider が利用できない可能性があるため、
+ * 依存のない素の HTML で表示する。
+ */
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <html lang="ja">
+      <body>
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            minHeight: '100vh',
+            fontFamily: 'sans-serif',
+            gap: '16px',
+            padding: '16px',
+          }}
+        >
+          <h2>エラーが発生しました</h2>
+          <p>
+            アプリケーションの表示中に問題が発生しました。
+            再試行しても解決しない場合は、時間をおいてからアクセスしてください。
+          </p>
+          {error.digest && <p style={{ color: '#888' }}>エラーID: {error.digest}</p>}
+          <button
+            type="button"
+            onClick={() => reset()}
+            style={{ padding: '8px 24px', cursor: 'pointer' }}
+          >
+            再試行
+          </button>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/frontend/src/app/import/loading.tsx
+++ b/frontend/src/app/import/loading.tsx
@@ -1,0 +1,5 @@
+import { PageLoader } from '@/components/PageLoader';
+
+export default function Loading() {
+  return <PageLoader message="インポート画面を読み込み中..." />;
+}

--- a/frontend/src/app/more/loading.tsx
+++ b/frontend/src/app/more/loading.tsx
@@ -1,0 +1,5 @@
+import { PageLoader } from '@/components/PageLoader';
+
+export default function Loading() {
+  return <PageLoader message="メニューを読み込み中..." />;
+}

--- a/frontend/src/app/print-templates/loading.tsx
+++ b/frontend/src/app/print-templates/loading.tsx
@@ -1,0 +1,5 @@
+import { PageLoader } from '@/components/PageLoader';
+
+export default function Loading() {
+  return <PageLoader message="印刷テンプレートを読み込み中..." />;
+}

--- a/frontend/src/app/staff/shifts/loading.tsx
+++ b/frontend/src/app/staff/shifts/loading.tsx
@@ -1,0 +1,5 @@
+import { PageLoader } from '@/components/PageLoader';
+
+export default function Loading() {
+  return <PageLoader message="シフト表を読み込み中..." />;
+}

--- a/frontend/src/app/tenants/loading.tsx
+++ b/frontend/src/app/tenants/loading.tsx
@@ -1,0 +1,5 @@
+import { PageLoader } from '@/components/PageLoader';
+
+export default function Loading() {
+  return <PageLoader message="ユーザー設定を読み込み中..." />;
+}

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -39,7 +39,7 @@ import {
   IconPhoto,
   IconUsers,
 } from '@tabler/icons-react';
-import { useAuth } from '@/lib/auth/store';
+import { useAuth, useCan } from '@/lib/auth/store';
 import { isAuthRoute, isProtectedRoute } from '@/lib/auth/routes';
 import { notifications } from '@mantine/notifications';
 import { usePageHeader } from '@/lib/contexts/page-header-context';
@@ -48,11 +48,23 @@ import { apiClient, type ApiQueryParams } from '@/lib/api/client';
 import type { Cat } from '@/lib/api/hooks/use-cats';
 import { useBottomNavSettings } from '@/lib/hooks/use-bottom-nav-settings';
 
-const navigationItems = [
+import type { Permission } from '@/lib/auth/permissions';
+
+interface NavigationItem {
+  label: string;
+  href: string;
+  icon: React.ComponentType<{ size?: number | string; stroke?: number | string }>;
+  /** 指定時、この権限を持たないユーザーにはナビゲーションに表示しない */
+  requiredPermission?: Permission;
+}
+
+const navigationItems: NavigationItem[] = [
   {
     label: '新規猫登録',
     href: '/cats/new',
     icon: IconPaw,
+    // 作成専用ページのため cats:write がないユーザーには表示しない
+    requiredPermission: 'cats:write',
   },
   {
     label: '在舎猫一覧',
@@ -146,6 +158,7 @@ export function AppLayout({ children }: AppLayoutProps) {
   const [mobileOpened, { toggle: toggleMobile, close: closeMobile }] = useDisclosure(false);
   const [desktopOpened, { toggle: toggleDesktop, close: closeDesktop }] = useDisclosure(false);
   const { user, isAuthenticated, initialized, isLoading, logout } = useAuth();
+  const can = useCan();
   const [logoutLoading, setLogoutLoading] = useState(false);
 
   const isAuthPage = isAuthRoute(pathname);
@@ -486,7 +499,9 @@ export function AppLayout({ children }: AppLayoutProps) {
 
             <AppShell.Section grow component={ScrollArea}>
               <Stack gap={4}>
-                {navigationItems.map((item) => {
+                {navigationItems
+                  .filter((item) => !item.requiredPermission || can(item.requiredPermission))
+                  .map((item) => {
                   const Icon = item.icon;
                   const isActive = pathname === item.href;
 


### PR DESCRIPTION
## 概要

残タスクの実装です: **権限システム Phase 2（全機能への適用）+ error.tsx 補完 + e2e テスト全 green 化**。

## 1. 権限システム Phase 2

- **全19コントローラ・約98の書き込みエンドポイント**（POST/PATCH/PUT/DELETE）に `@RequirePermissions` + `PermissionsGuard` を適用。閲覧（GET）は従来どおり全ログインユーザー
- マッピング: cats（体重・タグ付与含む）→ `cats:write` / breeding 一式 → `breeding:write` / ケア → `care:write` / 医療 → `medical:write` / タグ定義・自動化 → `tags:manage` / 血統書 → `pedigree:write` / ギャラリー → `gallery:write` / スタッフ・シフト → `staff:manage` / 卒業 → `graduation:write` / 入出力 → `data:import_export` / マスタ・テンプレート・表示設定 → `settings:manage`
- breeds / coat-colors / pedigree の旧 `@Roles(ADMIN, SUPER_ADMIN)` + RoleGuard を置換
- `/auth/register` の自己登録ユーザーにも USER プリセット権限を付与（招待経路と一貫。これがないと登録直後に日常記録も403）
- ナビゲーション出し分け: 作成専用ページ（新規猫登録）は `cats:write` がないと非表示

**実機検証**: 制限ユーザー（cats:write のみ）で 猫作成201 / 閲覧200 / ケア・タグ・スタッフ・配種・エクスポート403（必要権限名入りの日本語メッセージ）を確認済み。

## 2. error boundary / loading（H-7）

- ルート `error.tsx`（日本語案内+再試行+エラーID）と `global-error.tsx`（依存なしフォールバック）を新設
- loading.tsx 未配置だった6セグメントを補完

## 3. e2e テスト整備 — **全14スイート・105件が初めて完全 green（exit 0）**

**テスト基盤の重要な修正**:
- `prisma.seed` フック未設定で reset 時にシードが走らず、シード前提のスイートが常に失敗していた → フック追加
- **`test:e2e` の for ループが失敗を伝播せず、スイートが失敗しても CI の E2E ジョブが常に green だった** → `|| exit 1` で失敗伝播（CI が初めて正直になります）
- テストアプリに本番同等の helmet / CORS / インターセプタ構成を適用

**仕様追従**: pedigree（認証必須化 + 401/403テスト再構成）、export（@HttpCode(200) の製品修正 + 管理者ログイン）、import / care-and-tags / care-tags / breeds-coat-colors（権限ベースの役割分担を反映）

## 品質ゲート

e2e 14スイート105件 ✅ / backend unit 325件 ✅ / frontend unit 27件 ✅ / 両 lint・build ✅

## デプロイ時の注意

- スキーマ変更なし（migration 追加なし）
- 既存ユーザーはロール相当の権限がバックフィル済み（#228）のため、**挙動は従来と変わりません**
- 注意: 本PR以降、CI の E2E ジョブは実際の失敗を正しく検出するようになります

https://claude.ai/code/session_01LBnxBEBnyakawBoac6G78P

---
_Generated by [Claude Code](https://claude.ai/code/session_01LBnxBEBnyakawBoac6G78P)_