### PR TITLE
fix(ci): 本番デプロイ失敗の真因修正 — vendor tarball をビルドコンテキストに含める

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -8,6 +8,9 @@ FROM base AS development
 # 開発モード: ホットリロード対応
 # ソースコードはボリュームマウントされるため、COPY は最小限にとどめる
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+# root devDependencies が file:vendor/*.tgz を参照しているため、
+# これが無いと pnpm install --frozen-lockfile が ENOENT で失敗する
+COPY vendor ./vendor
 COPY backend/package.json ./backend/
 # pnpm workspace の依存関係解決に必要（frontend への参照がある場合に備える）
 COPY frontend/package.json ./frontend/
@@ -35,6 +38,9 @@ CMD ["pnpm", "--filter", "backend", "run", "start:dev"]
 # ---- Build Stage ----
 FROM base AS build
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+# root devDependencies が file:vendor/*.tgz を参照しているため、
+# これが無いと pnpm install --frozen-lockfile が ENOENT で失敗する
+COPY vendor ./vendor
 COPY backend/package.json ./backend/
 COPY frontend/package.json ./frontend/
 COPY backend/prisma ./backend/prisma
@@ -64,6 +70,9 @@ RUN apk add --no-cache openssl libc6-compat && \
 
 # Copy workspace config and package files for production install
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+# root devDependencies が file:vendor/*.tgz を参照しているため、
+# これが無いと pnpm install --frozen-lockfile が ENOENT で失敗する
+COPY vendor ./vendor
 COPY backend/package.json ./backend/
 COPY frontend/package.json ./frontend/
 COPY backend/prisma ./backend/prisma

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -8,6 +8,9 @@ FROM base AS development
 # 開発モード: Next.js Fast Refresh 対応
 # ソースコードはボリュームマウントされるため、COPY は最小限にとどめる
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+# root devDependencies が file:vendor/*.tgz を参照しているため、
+# これが無いと pnpm install --frozen-lockfile が ENOENT で失敗する
+COPY vendor ./vendor
 COPY backend/package.json ./backend/
 COPY frontend/package.json ./frontend/
 
@@ -23,6 +26,9 @@ CMD ["pnpm", "--filter", "frontend", "run", "dev"]
 # ---- Build Stage ----
 FROM base AS build
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+# root devDependencies が file:vendor/*.tgz を参照しているため、
+# これが無いと pnpm install --frozen-lockfile が ENOENT で失敗する
+COPY vendor ./vendor
 COPY backend/package.json ./backend/
 COPY frontend/package.json ./frontend/
 


### PR DESCRIPTION
## 概要

**本番デプロイ失敗（Cloud Build step 0 / exit 254）の真因修正**です。#230 の mirror.gcr.io 化では解消しなかったため、マージコミットでのデプロイ失敗を追跡調査しました。

## 真因

- **5/29 の Last-Mile devtools 導入コミット（`8d5ce7c`）** で root の `package.json` が `vendor/last-mile/*.tgz` をローカル tarball（`file:` 参照）として devDependencies / overrides に追加
- しかし **Dockerfile は `vendor/` を COPY していなかった**ため、イメージ内の `pnpm install --frozen-lockfile` が `file:vendor/...` の解決で **ENOENT** となり失敗
- デプロイ失敗の開始時期（最終成功 4/22 → 失敗開始 5/29）がこのコミットと完全に一致

## 検証

イメージ内のファイル構成（package.json / pnpm-lock.yaml / pnpm-workspace.yaml / backend/frontend の package.json / prisma のみ）をホスト上で忠実に再現:

- vendor なし → `ENOENT: no such file or directory, open '.../vendor/last-mile/last-mile-context-cli-0.1.0.tgz'` （Cloud Build の失敗を完全再現）
- vendor あり → `pnpm install --frozen-lockfile --filter backend...` 成功 ✅（`--prod` も成功 ✅）

## 修正

両 Dockerfile の `pnpm install` を行う全ステージ（backend 3ステージ + frontend 2ステージ）に `COPY vendor ./vendor` を追加。

**この PR のマージで、4/22 以降止まっていた本番デプロイが復旧する見込みです。** マージ後のデプロイ完走をこちらで監視・確認します。

https://claude.ai/code/session_01LBnxBEBnyakawBoac6G78P

---
_Generated by [Claude Code](https://claude.ai/code/session_01LBnxBEBnyakawBoac6G78P)_