### PR TITLE
feat(cats,staff): 猫の親情報入力UIとモバイルのスタッフ管理UIを追加

### DIFF
--- a/backend/src/cats/cats.service.ts
+++ b/backend/src/cats/cats.service.ts
@@ -51,6 +51,8 @@ export class CatsService {
       isInHouse,
       fatherId,
       motherId,
+      fatherName,
+      motherName,
       tagIds,
     } = createCatDto;
 
@@ -113,8 +115,17 @@ export class CatsService {
           isInHouse: isInHouse ?? true,
           ...(breedIdToConnect ? { breed: { connect: { id: breedIdToConnect } } } : {}),
           ...(coatColorIdToConnect ? { coatColor: { connect: { id: coatColorIdToConnect } } } : {}),
-          ...(fatherId ? { father: { connect: { id: fatherId } } } : {}),
-          ...(motherId ? { mother: { connect: { id: motherId } } } : {}),
+          // 親はリレーション優先。ID 未指定かつ名前のみの場合はテキストとして記録（システム未登録の親）
+          ...(fatherId
+            ? { father: { connect: { id: fatherId } } }
+            : fatherName
+              ? { fatherName }
+              : {}),
+          ...(motherId
+            ? { mother: { connect: { id: motherId } } }
+            : motherName
+              ? { motherName }
+              : {}),
         },
         include: catWithRelationsInclude,
       });
@@ -169,6 +180,12 @@ export class CatsService {
           throw new ConflictException("Cat with the same microchip number already exists");
         }
         throw new ConflictException("Cat with the same registration number already exists");
+      }
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === "P2025"
+      ) {
+        throw new BadRequestException("指定された親猫が見つかりません");
       }
       throw error;
     }
@@ -297,8 +314,15 @@ export class CatsService {
       isInHouse,
       fatherId,
       motherId,
+      fatherName,
+      motherName,
       tagIds,
     } = updateCatDto;
+
+    // 自分自身を親に設定することはできない
+    if (fatherId === id || motherId === id) {
+      throw new BadRequestException("自分自身を親に設定することはできません");
+    }
 
     // Validate breed if provided
     let breedIdToConnect: string | undefined;
@@ -378,8 +402,21 @@ export class CatsService {
           ...(isInHouse !== undefined ? { isInHouse } : {}),
           ...(breedIdToConnect ? { breed: { connect: { id: breedIdToConnect } } } : {}),
           ...(coatColorIdToConnect ? { coatColor: { connect: { id: coatColorIdToConnect } } } : {}),
-          ...(fatherId ? { father: { connect: { id: fatherId } } } : {}),
-          ...(motherId ? { mother: { connect: { id: motherId } } } : {}),
+          // 親情報: ID 指定で接続（名前はクリア）、null で解除、ID 未変更時は名前のみ更新可
+          ...(fatherId
+            ? { father: { connect: { id: fatherId } }, fatherName: null }
+            : fatherId === null
+              ? { father: { disconnect: true }, fatherName: fatherName ?? null }
+              : fatherName !== undefined
+                ? { fatherName }
+                : {}),
+          ...(motherId
+            ? { mother: { connect: { id: motherId } }, motherName: null }
+            : motherId === null
+              ? { mother: { disconnect: true }, motherName: motherName ?? null }
+              : motherName !== undefined
+                ? { motherName }
+                : {}),
         },
         include: catWithRelationsInclude,
       });
@@ -398,6 +435,12 @@ export class CatsService {
           throw new ConflictException("Cat with the same microchip number already exists");
         }
         throw new ConflictException("Cat with the same registration number already exists");
+      }
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === "P2025"
+      ) {
+        throw new BadRequestException("指定された親猫が見つかりません");
       }
       throw error;
     }

--- a/backend/src/cats/dto/create-cat.dto.ts
+++ b/backend/src/cats/dto/create-cat.dto.ts
@@ -71,6 +71,18 @@ export class CreateCatDto {
   @IsString()
   motherId?: string;
 
+  @ApiPropertyOptional({ description: "父猫の名前（システム未登録の親を記録する場合）" })
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  fatherName?: string;
+
+  @ApiPropertyOptional({ description: "母猫の名前（システム未登録の親を記録する場合）" })
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  motherName?: string;
+
   @ApiPropertyOptional({ description: "タグID配列" })
   @IsOptional()
   @IsArray()

--- a/backend/src/cats/dto/update-cat.dto.ts
+++ b/backend/src/cats/dto/update-cat.dto.ts
@@ -1,10 +1,41 @@
-import { PartialType } from "@nestjs/mapped-types";
-import { IsIn, IsOptional } from "class-validator";
+import { OmitType, PartialType } from "@nestjs/mapped-types";
+import { ApiPropertyOptional } from "@nestjs/swagger";
+import { IsIn, IsOptional, IsString, MaxLength, ValidateIf } from "class-validator";
 
 import { CreateCatDto } from "./create-cat.dto";
 
-export class UpdateCatDto extends PartialType(CreateCatDto) {
+// 親情報は null（解除）を許容するため、基底の string 型定義から除外して再定義する
+export class UpdateCatDto extends PartialType(
+  OmitType(CreateCatDto, ["fatherId", "motherId", "fatherName", "motherName"] as const),
+) {
   @IsOptional()
   @IsIn(["MALE", "FEMALE", "NEUTER", "SPAY"])
   gender?: "MALE" | "FEMALE" | "NEUTER" | "SPAY";
+
+  // 親情報は null を「解除」として受け付けるため、PartialType の定義を上書きする
+  @ApiPropertyOptional({ description: "父猫のID（null で関連を解除）" })
+  @IsOptional()
+  @ValidateIf((_object, value) => value !== null)
+  @IsString()
+  fatherId?: string | null;
+
+  @ApiPropertyOptional({ description: "母猫のID（null で関連を解除）" })
+  @IsOptional()
+  @ValidateIf((_object, value) => value !== null)
+  @IsString()
+  motherId?: string | null;
+
+  @ApiPropertyOptional({ description: "父猫の名前（null でクリア）" })
+  @IsOptional()
+  @ValidateIf((_object, value) => value !== null)
+  @IsString()
+  @MaxLength(200)
+  fatherName?: string | null;
+
+  @ApiPropertyOptional({ description: "母猫の名前（null でクリア）" })
+  @IsOptional()
+  @ValidateIf((_object, value) => value !== null)
+  @IsString()
+  @MaxLength(200)
+  motherName?: string | null;
 }

--- a/frontend/src/app/cats/[id]/client.tsx
+++ b/frontend/src/app/cats/[id]/client.tsx
@@ -287,6 +287,9 @@ export default function CatDetailClient({ catId }: Props) {
                       >
                         {catData.father.name}
                       </Button>
+                    ) : catData.fatherName ? (
+                      // システム未登録の親（名前のみ記録）
+                      <Text>{catData.fatherName}</Text>
                     ) : (
                       <Text c="dimmed">未登録</Text>
                     )}
@@ -301,6 +304,9 @@ export default function CatDetailClient({ catId }: Props) {
                       >
                         {catData.mother.name}
                       </Button>
+                    ) : catData.motherName ? (
+                      // システム未登録の親（名前のみ記録）
+                      <Text>{catData.motherName}</Text>
                     ) : (
                       <Text c="dimmed">未登録</Text>
                     )}

--- a/frontend/src/app/cats/[id]/edit/client.tsx
+++ b/frontend/src/app/cats/[id]/edit/client.tsx
@@ -4,7 +4,7 @@ import { useRouter } from "next/navigation";
 import { Container, Title, Paper, Group, Button, Stack, TextInput, Textarea, Select, Loader, Center, Alert } from "@mantine/core";
 import { IconArrowLeft, IconDeviceFloppy, IconAlertCircle } from "@tabler/icons-react";
 import { useEffect, useMemo, useState } from "react";
-import { useGetCat, useUpdateCat, useDeleteCat } from "@/lib/api/hooks/use-cats";
+import { useGetCat, useGetCats, useUpdateCat, useDeleteCat } from "@/lib/api/hooks/use-cats";
 import { useGetBreeds } from "@/lib/api/hooks/use-breeds";
 import { useGetCoatColors } from "@/lib/api/hooks/use-coat-colors";
 import { useBreedMasterData, useCoatColorMasterData } from "@/lib/api/hooks/use-master-data";
@@ -45,6 +45,24 @@ export default function CatEditClient({ catId }: Props) {
   const updateCat = useUpdateCat(catId);
   const deleteCat = useDeleteCat();
 
+  // 親猫の選択肢（登録済みの猫から性別で絞り込み、自分自身は除外）
+  const parentListQuery = useMemo(() => ({ limit: 1000 }), []);
+  const { data: parentCatsData, isLoading: isParentCatsLoading } = useGetCats(parentListQuery);
+  const fatherOptions = useMemo(
+    () =>
+      (parentCatsData?.data ?? [])
+        .filter((c) => c.id !== catId && (c.gender === "MALE" || c.gender === "NEUTER"))
+        .map((c) => ({ value: c.id, label: c.name })),
+    [parentCatsData, catId],
+  );
+  const motherOptions = useMemo(
+    () =>
+      (parentCatsData?.data ?? [])
+        .filter((c) => c.id !== catId && (c.gender === "FEMALE" || c.gender === "SPAY"))
+        .map((c) => ({ value: c.id, label: c.name })),
+    [parentCatsData, catId],
+  );
+
   const [form, setForm] = useState<{
     name: string;
     gender: 'MALE' | 'FEMALE' | 'NEUTER' | 'SPAY';
@@ -54,6 +72,10 @@ export default function CatEditClient({ catId }: Props) {
     microchipNumber: string;
     registrationNumber: string;
     description: string;
+    fatherId: string;
+    motherId: string;
+    fatherName: string;
+    motherName: string;
   }>({
     name: "",
     gender: "MALE",
@@ -63,6 +85,10 @@ export default function CatEditClient({ catId }: Props) {
     microchipNumber: "",
     registrationNumber: "",
     description: "",
+    fatherId: "",
+    motherId: "",
+    fatherName: "",
+    motherName: "",
   });
 
   // データ取得後にフォームを初期化
@@ -78,6 +104,10 @@ export default function CatEditClient({ catId }: Props) {
         microchipNumber: catData.microchipNumber || "",
         registrationNumber: catData.registrationNumber || "",
         description: catData.description || "",
+        fatherId: catData.fatherId || "",
+        motherId: catData.motherId || "",
+        fatherName: catData.fatherName || "",
+        motherName: catData.motherName || "",
       });
     }
   }, [cat]);
@@ -102,6 +132,11 @@ export default function CatEditClient({ catId }: Props) {
         microchipNumber: form.microchipNumber || null,
         registrationNumber: form.registrationNumber || null,
         description: form.description || null,
+        // 親情報: ID 指定で接続、空なら解除。名前テキストは未登録の親の記録用
+        fatherId: form.fatherId || null,
+        motherId: form.motherId || null,
+        fatherName: form.fatherId ? null : form.fatherName.trim() || null,
+        motherName: form.motherId ? null : form.motherName.trim() || null,
       });
 
       router.push(`/cats/${catId}`);
@@ -229,6 +264,56 @@ export default function CatEditClient({ catId }: Props) {
               onChange={(e) => handleChange("registrationNumber", e.target.value)}
               placeholder="血統書登録番号"
             />
+
+            <Group grow>
+              <Select
+                label="父猫（登録済みから選択）"
+                value={form.fatherId || null}
+                onChange={(value) => {
+                  handleChange("fatherId", value || "");
+                  if (value) {
+                    // リレーションを優先するため名前テキストはクリア
+                    handleChange("fatherName", "");
+                  }
+                }}
+                data={fatherOptions}
+                searchable
+                clearable
+                disabled={updateCat.isPending || isParentCatsLoading}
+              />
+              <Select
+                label="母猫（登録済みから選択）"
+                value={form.motherId || null}
+                onChange={(value) => {
+                  handleChange("motherId", value || "");
+                  if (value) {
+                    // リレーションを優先するため名前テキストはクリア
+                    handleChange("motherName", "");
+                  }
+                }}
+                data={motherOptions}
+                searchable
+                clearable
+                disabled={updateCat.isPending || isParentCatsLoading}
+              />
+            </Group>
+
+            <Group grow>
+              <TextInput
+                label="父猫名（未登録の場合に入力）"
+                value={form.fatherName}
+                onChange={(e) => handleChange("fatherName", e.target.value)}
+                disabled={!!form.fatherId}
+                placeholder="システム未登録の父猫の名前"
+              />
+              <TextInput
+                label="母猫名（未登録の場合に入力）"
+                value={form.motherName}
+                onChange={(e) => handleChange("motherName", e.target.value)}
+                disabled={!!form.motherId}
+                placeholder="システム未登録の母猫の名前"
+              />
+            </Group>
 
             <Textarea
               label="詳細説明"

--- a/frontend/src/app/cats/new/page.tsx
+++ b/frontend/src/app/cats/new/page.tsx
@@ -16,7 +16,7 @@ import { TextareaWithFloatingLabel } from '@/components/ui/TextareaWithFloatingL
 import { Controller, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { IconPlus } from '@tabler/icons-react';
-import { useCreateCat, useGetCat, type Cat, type CreateCatRequest } from '@/lib/api/hooks/use-cats';
+import { useCreateCat, useGetCat, useGetCats, type Cat, type CreateCatRequest } from '@/lib/api/hooks/use-cats';
 import { useGetBreeds } from '@/lib/api/hooks/use-breeds';
 import { useGetCoatColors } from '@/lib/api/hooks/use-coat-colors';
 import { useBreedMasterData, useCoatColorMasterData } from '@/lib/api/hooks/use-master-data';
@@ -54,11 +54,30 @@ export default function CatRegistrationPage() {
     () => buildMasterOptions(coatColorsData?.data, coatDisplayMap),
     [coatColorsData, coatDisplayMap],
   );
+  // 親猫の選択肢（登録済みの猫から性別で絞り込み）
+  const parentListQuery = useMemo(() => ({ limit: 1000 }), []);
+  const { data: parentCatsData, isLoading: isParentCatsLoading } = useGetCats(parentListQuery);
+  const fatherOptions = useMemo(
+    () =>
+      (parentCatsData?.data ?? [])
+        .filter((cat) => cat.gender === 'MALE' || cat.gender === 'NEUTER')
+        .map((cat) => ({ value: cat.id, label: cat.name })),
+    [parentCatsData],
+  );
+  const motherOptions = useMemo(
+    () =>
+      (parentCatsData?.data ?? [])
+        .filter((cat) => cat.gender === 'FEMALE' || cat.gender === 'SPAY')
+        .map((cat) => ({ value: cat.id, label: cat.name })),
+    [parentCatsData],
+  );
   const {
     control,
     handleSubmit,
     formState: { errors },
     reset,
+    setValue,
+    watch,
   } = useForm<CatFormValues>({
     resolver: zodResolver(catFormSchema),
     defaultValues: {
@@ -72,8 +91,16 @@ export default function CatRegistrationPage() {
       description: undefined,
       isInHouse: true,
       tagIds: [],
+      fatherId: undefined,
+      motherId: undefined,
+      fatherName: undefined,
+      motherName: undefined,
     },
   });
+
+  // 親猫が選択されている間は名前テキストを使用しない
+  const selectedFatherId = watch('fatherId');
+  const selectedMotherId = watch('motherId');
 
   const { data: sourceCatData } = useGetCat(copyFromId ?? '', { enabled: !!copyFromId });
   useEffect(() => {
@@ -90,6 +117,10 @@ export default function CatRegistrationPage() {
       description: src.description ?? undefined,
       isInHouse: src.isInHouse ?? true,
       tagIds: src.tags?.map(t => t.tag.id) ?? [],
+      fatherId: src.fatherId ?? undefined,
+      motherId: src.motherId ?? undefined,
+      fatherName: src.fatherName ?? undefined,
+      motherName: src.motherName ?? undefined,
     });
   }, [sourceCatData, reset]);
 
@@ -105,6 +136,11 @@ export default function CatRegistrationPage() {
       description: values.description,
       isInHouse: values.isInHouse ?? true,
       tagIds: (values.tagIds ?? []).length > 0 ? values.tagIds : undefined,
+      fatherId: values.fatherId,
+      motherId: values.motherId,
+      // 登録済みの親を選択した場合は名前テキストを送らない（リレーション優先）
+      fatherName: values.fatherId ? undefined : values.fatherName,
+      motherName: values.motherId ? undefined : values.motherName,
     };
 
     try {
@@ -279,7 +315,87 @@ export default function CatRegistrationPage() {
                   />
                 </Group>
 
-                {/* 4行目: 備考 */}
+                {/* 4行目: 親情報（登録済みの猫から選択、未登録の親は名前を直接入力） */}
+                <Group grow gap={10}>
+                  <Controller
+                    name="fatherId"
+                    control={control}
+                    render={({ field }) => (
+                      <SelectWithFloatingLabel
+                        label="父猫（登録済みから選択）"
+                        data={fatherOptions}
+                        searchable
+                        clearable
+                        disabled={isSubmitting || isParentCatsLoading}
+                        error={errors.fatherId?.message}
+                        value={field.value ?? null}
+                        onChange={(next) => {
+                          field.onChange(next ?? undefined);
+                          if (next) {
+                            // リレーションを優先するため名前テキストはクリア
+                            setValue('fatherName', undefined);
+                          }
+                        }}
+                      />
+                    )}
+                  />
+
+                  <Controller
+                    name="motherId"
+                    control={control}
+                    render={({ field }) => (
+                      <SelectWithFloatingLabel
+                        label="母猫（登録済みから選択）"
+                        data={motherOptions}
+                        searchable
+                        clearable
+                        disabled={isSubmitting || isParentCatsLoading}
+                        error={errors.motherId?.message}
+                        value={field.value ?? null}
+                        onChange={(next) => {
+                          field.onChange(next ?? undefined);
+                          if (next) {
+                            // リレーションを優先するため名前テキストはクリア
+                            setValue('motherName', undefined);
+                          }
+                        }}
+                      />
+                    )}
+                  />
+                </Group>
+
+                {/* 5行目: 未登録の親の名前（選択済みの場合は入力不可） */}
+                <Group grow gap={10}>
+                  <Controller
+                    name="fatherName"
+                    control={control}
+                    render={({ field }) => (
+                      <InputWithFloatingLabel
+                        label="父猫名（未登録の場合に入力）"
+                        error={errors.fatherName?.message}
+                        disabled={isSubmitting || !!selectedFatherId}
+                        {...field}
+                        value={field.value ?? ''}
+                      />
+                    )}
+                  />
+
+                  <Controller
+                    name="motherName"
+                    control={control}
+                    render={({ field }) => (
+                      <InputWithFloatingLabel
+                        label="母猫名（未登録の場合に入力）"
+                        error={errors.motherName?.message}
+                        disabled={isSubmitting || !!selectedMotherId}
+                        {...field}
+                        value={field.value ?? ''}
+                      />
+                    )}
+                  />
+                </Group>
+
+                {/* 6行目: 備考 */}
                 <Controller
                   name="description"
                   control={control}
@@ -295,7 +411,7 @@ export default function CatRegistrationPage() {
                   )}
                 />
 
-                {/* 5行目: タグ */}
+                {/* 7行目: タグ */}
                 <Controller
                   name="tagIds"
                   control={control}
@@ -310,7 +426,7 @@ export default function CatRegistrationPage() {
                   )}
                 />
 
-                {/* 6行目: 在舎スイッチ */}
+                {/* 8行目: 在舎スイッチ */}
                 <Controller
                   name="isInHouse"
                   control={control}

--- a/frontend/src/app/staff/shifts/page.tsx
+++ b/frontend/src/app/staff/shifts/page.tsx
@@ -193,6 +193,8 @@ export default function StaffShiftsPage() {
   const [editOpened, { open: openEdit, close: closeEdit }] = useDisclosure(false);
   const [deleteOpened, { open: openDelete, close: closeDelete }] = useDisclosure(false);
   const [selectStaffOpened, { open: openSelectStaff, close: closeSelectStaff }] = useDisclosure(false);
+  // モバイル用スタッフ管理モーダル（追加・編集・削除の入口）
+  const [manageOpened, { open: openManage, close: closeManage }] = useDisclosure(false);
   const [operationLoading, setOperationLoading] = useState(false);
 
   // テンプレート入力用スタッフ選択
@@ -843,6 +845,87 @@ export default function StaffShiftsPage() {
     <Container size="xl">
       <LoadingOverlay visible={loading} />
 
+      {/* スタッフ管理モーダル（モバイル用の追加・編集・削除の入口）。
+          作成・編集・削除モーダルより先にマウントし、それらが手前に表示されるようにする */}
+      <UnifiedModal
+        opened={manageOpened}
+        onClose={closeManage}
+        title="スタッフ管理"
+        size="md"
+        sections={[
+          {
+            content: (
+              <Stack gap="xs">
+                {staffList.length === 0 ? (
+                  <Text size="sm" c="dimmed">
+                    スタッフが登録されていません。
+                  </Text>
+                ) : (
+                  staffList.map((staff) => {
+                    // 勤務時間テンプレートを表示用に整形
+                    const timeLabel = staff.workTimeTemplate
+                      ? `${staff.workTimeTemplate.startHour}〜${staff.workTimeTemplate.endHour}`
+                      : '';
+
+                    return (
+                      <Group key={staff.id} justify="space-between" wrap="nowrap">
+                        <Group gap={8} wrap="nowrap" style={{ minWidth: 0 }}>
+                          <Box
+                            style={{
+                              width: 10,
+                              height: 10,
+                              borderRadius: '50%',
+                              backgroundColor: staff.color,
+                              flexShrink: 0,
+                            }}
+                          />
+                          <Text size="sm" fw={500} truncate>
+                            {staff.name}
+                            {timeLabel && (
+                              <Text component="span" size="xs" c="dimmed" ml={6}>
+                                {timeLabel}
+                              </Text>
+                            )}
+                          </Text>
+                        </Group>
+                        <Group gap={4} wrap="nowrap">
+                          <ActionIcon
+                            variant="subtle"
+                            aria-label={`${staff.name}を編集`}
+                            data-testid="staff-manage-edit"
+                            onClick={() => openEditModal(staff)}
+                          >
+                            <IconEdit size={16} />
+                          </ActionIcon>
+                          <ActionIcon
+                            variant="subtle"
+                            color="red"
+                            aria-label={`${staff.name}を削除`}
+                            data-testid="staff-manage-delete"
+                            onClick={() => openDeleteModal(staff)}
+                          >
+                            <IconTrash size={16} />
+                          </ActionIcon>
+                        </Group>
+                      </Group>
+                    );
+                  })
+                )}
+              </Stack>
+            ),
+          },
+          {
+            content: (
+              <Group justify="flex-end">
+                <Button leftSection={<IconPlus size={16} />} onClick={openCreate}>
+                  スタッフ追加
+                </Button>
+              </Group>
+            ),
+          },
+        ]}
+      />
+
       {/* スタッフ作成モーダル */}
       <UnifiedModal
         opened={createOpened}
@@ -1273,14 +1356,27 @@ export default function StaffShiftsPage() {
       >
         {/* 左サイドバー: スタッフ一覧 / モバイルではバッジのみ */}
         {isMobile ? (
-          /* モバイル: バッジ形式スタッフ一覧（全角3文字幅） */
-          <ScrollArea
-            id="staff-list"
+          /* モバイル: バッジ形式スタッフ一覧（全角3文字幅）+ スタッフ管理ボタン */
+          <Stack
+            gap={6}
             style={{
               width: 56, // 全角3文字幅 + padding
               flexShrink: 0,
             }}
           >
+            <Tooltip label="スタッフ管理（追加・編集・削除）" position="right" withArrow>
+              <ActionIcon
+                variant="light"
+                size={48}
+                radius="sm"
+                onClick={openManage}
+                aria-label="スタッフ管理"
+                data-testid="staff-manage-open"
+              >
+                <IconUsers size={24} />
+              </ActionIcon>
+            </Tooltip>
+            <ScrollArea id="staff-list" style={{ flex: 1 }}>
             <Stack gap={6}>
               {staffList.map((staff) => (
                 <Tooltip
@@ -1316,7 +1412,8 @@ export default function StaffShiftsPage() {
                 </Tooltip>
               ))}
             </Stack>
-          </ScrollArea>
+            </ScrollArea>
+          </Stack>
         ) : (
           /* デスクトップ: 1行形式スタッフ一覧（リサイズ可能） */
           <Box style={{ display: 'flex', flexShrink: 0 }}>

--- a/frontend/src/lib/api/hooks/use-cats.ts
+++ b/frontend/src/lib/api/hooks/use-cats.ts
@@ -23,6 +23,9 @@ export interface Cat {
   isInHouse: boolean;
   fatherId: string | null;
   motherId: string | null;
+  /** システム未登録の親の名前（親猫削除時のスナップショット含む） */
+  fatherName?: string | null;
+  motherName?: string | null;
   createdAt: string;
   updatedAt: string;
   // リレーション（オプショナル）
@@ -88,6 +91,8 @@ export interface CreateCatRequest {
   isInHouse?: boolean;
   fatherId?: string | null;
   motherId?: string | null;
+  fatherName?: string | null;
+  motherName?: string | null;
   tagIds?: string[];
 }
 

--- a/frontend/src/lib/schemas/cat.ts
+++ b/frontend/src/lib/schemas/cat.ts
@@ -19,6 +19,11 @@ export const catFormSchema = z.object({
   description: optionalTrimmedString,
   isInHouse: z.boolean().optional(),
   tagIds: z.array(z.string()).optional(),
+  // 親情報: 登録済みの猫から選択（ID）または未登録の親の名前テキスト
+  fatherId: optionalTrimmedString,
+  motherId: optionalTrimmedString,
+  fatherName: optionalTrimmedString,
+  motherName: optionalTrimmedString,
 });
 
 export type CatFormSchema = z.infer<typeof catFormSchema>;


### PR DESCRIPTION
# 概要

本番デプロイ後の実機検証で判明した 2 件の UI 欠落を修正します。

## 1. スタッフシフトページ: モバイル幅でスタッフの追加・編集・削除ができない

- モバイル表示（768px 以下）ではスタッフがドラッグ用バッジのみで表示され、編集・削除メニューも「操作」メニュー（スタッフ追加）も存在しなかった
- バッジ一覧の上に「スタッフ管理」ボタンを追加し、スタッフ一覧から編集・削除、フッターから追加ができるモーダルを新設
- 既存の作成・編集・削除モーダル/ハンドラをそのまま再利用（デスクトップの挙動は変更なし）

## 2. 猫の新規登録・編集フォーム: 親情報（父・母）の入力欄がない

- DB は `Cat.motherId` / `fatherId` の自己リレーション + `motherName` / `fatherName` の名前スナップショット列が既に存在し、バックエンドの DTO も ID を受け付けていたが、フォーム側に入力欄が一切なかった
- **登録済みの猫から検索選択**（性別で絞り込み・編集時は自分自身を除外）と、**システム未登録の親（外部スタッド等）の名前テキスト入力**の併用方式
- バックエンド更新セマンティクス: ID 指定で接続（名前テキストはクリア）、`null` で関連解除、名前のみの更新にも対応
- 自己参照ガード・存在しない親 ID は 400 + 日本語メッセージ
- 詳細ページの「親情報」表示に名前テキストのフォールバックを追加（リレーションなし・名前ありの場合はテキスト表示）

# 検証

- `pnpm lint` / `pnpm backend:build` / `pnpm frontend:build` すべて通過
- バックエンド unit テスト 325 件 / cats e2e 24 件 すべてパス
- ローカル環境（Docker PostgreSQL + 実サーバー）で API 検証:
  - fatherId 接続 + motherName テキストでの作成 ✅
  - motherId 接続で名前テキストが自動クリア ✅
  - `fatherId: null` + 名前テキストでリレーション解除→テキスト化 ✅
  - 自己参照 → 400「自分自身を親に設定することはできません」 ✅
  - 存在しない親 ID → 400「指定された親猫が見つかりません」 ✅
- ヘッドレスブラウザ（モバイル幅 390px）で UI 検証:
  - スタッフ管理ボタン表示 → モーダルに編集/削除アイコン → 編集モーダルが手前に開く ✅
  - 猫登録フォームで父猫を選択（父猫名入力が自動 disabled）+ 母猫名テキスト入力 → 登録 → リレーションとテキストが正しく保存 ✅

https://claude.ai/code/session_01LBnxBEBnyakawBoac6G78P

---
_Generated by [Claude Code](https://claude.ai/code/session_01LBnxBEBnyakawBoac6G78P)_