### PR TITLE
feat: 各ページの使い方を案内するオンボーディングを追加

### DIFF
--- a/frontend/e2e/onboarding.spec.ts
+++ b/frontend/e2e/onboarding.spec.ts
@@ -1,0 +1,69 @@
+/**
+ * オンボーディング E2E テスト
+ *
+ * カバー範囲:
+ * - ガイド定義のあるページの初回訪問で「できること」ドロワーが自動表示される
+ * - 一度表示したページは再訪しても自動表示されない（localStorage `mycats-onboarding` に記録）
+ * - ヘッダーの「?」ボタンでいつでも手動再表示できる
+ *
+ * 前提: 認証状態は setup プロジェクト（auth.setup.ts）の storageState を再利用。
+ * 各テストは新しいコンテキストで開始するため `mycats-onboarding` は未設定の状態から始まる。
+ *
+ * 設計メモ: 初回ログイン直後の着地ページは歓迎ヒント優先でガイドを見送るため、
+ * 先に `/` を開いて歓迎処理を通してから対象ページへ遷移する。
+ */
+
+import { test, expect } from './fixtures/base';
+
+const ONBOARDING_STORAGE_KEY = 'mycats-onboarding';
+
+test.describe('オンボーディング', () => {
+  test('在舎猫ページ初回訪問でガイドが自動表示され、再訪では表示されない', async ({ page }) => {
+    // 歓迎処理を先に通す（着地ページの自動表示は初回のみ見送られる設計）
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    // 初回訪問 → ドロワー自動表示（「了解しました」ボタンは開いている時だけ描画される）
+    await page.goto('/cats');
+    await page.waitForLoadState('networkidle');
+    const closeButton = page.getByTestId('page-onboarding-close');
+    await expect(closeButton).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('在舎猫の一覧でできること')).toBeVisible();
+
+    // localStorage に当該ページが記録されている
+    const stored = await page.evaluate(
+      (key) => localStorage.getItem(key),
+      ONBOARDING_STORAGE_KEY,
+    );
+    expect(stored).toContain('::cats');
+
+    // 閉じる
+    await closeButton.click();
+    await expect(closeButton).toBeHidden();
+
+    // 再訪 → 記録済みなので自動表示されない
+    await page.goto('/cats');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(1500);
+    await expect(page.getByTestId('page-onboarding-close')).toBeHidden();
+  });
+
+  test('ヘッダーの「?」ボタンでガイドを再表示できる', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    await page.goto('/cats');
+    await page.waitForLoadState('networkidle');
+
+    // 初回の自動表示を閉じる
+    const closeButton = page.getByTestId('page-onboarding-close');
+    await expect(closeButton).toBeVisible({ timeout: 10000 });
+    await closeButton.click();
+    await expect(closeButton).toBeHidden();
+
+    // 「?」ボタンで再表示
+    await page.getByTestId('page-onboarding-help').click();
+    await expect(page.getByTestId('page-onboarding-close')).toBeVisible();
+    await expect(page.getByText('在舎猫の一覧でできること')).toBeVisible();
+  });
+});

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -14,6 +14,8 @@ import {
   Box,
   Stack,
   Button,
+  ActionIcon,
+  Tooltip,
 } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -38,6 +40,7 @@ import {
   IconHeartHandshake,
   IconPhoto,
   IconUsers,
+  IconHelp,
 } from '@tabler/icons-react';
 import { useAuth } from '@/lib/auth/store';
 import { isAuthRoute, isProtectedRoute } from '@/lib/auth/routes';
@@ -47,6 +50,9 @@ import { ContextMenuManager } from '@/components/context-menu';
 import { apiClient, type ApiQueryParams } from '@/lib/api/client';
 import type { Cat } from '@/lib/api/hooks/use-cats';
 import { useBottomNavSettings } from '@/lib/hooks/use-bottom-nav-settings';
+import { useOnboardingStore } from '@/lib/store/onboarding-store';
+import { findPageGuide } from '@/lib/onboarding/page-guides';
+import { PageOnboardingHost } from '@/components/onboarding/PageOnboardingHost';
 
 const navigationItems = [
   {
@@ -147,6 +153,8 @@ export function AppLayout({ children }: AppLayoutProps) {
   const [desktopOpened, { toggle: toggleDesktop, close: closeDesktop }] = useDisclosure(false);
   const { user, isAuthenticated, initialized, isLoading, logout } = useAuth();
   const [logoutLoading, setLogoutLoading] = useState(false);
+  const requestGuideOpen = useOnboardingStore((state) => state.requestOpen);
+  const pageGuide = findPageGuide(pathname);
 
   const isAuthPage = isAuthRoute(pathname);
   const requiresAuth = isProtectedRoute(pathname);
@@ -436,6 +444,21 @@ export function AppLayout({ children }: AppLayoutProps) {
                 >
                   🎓 {catStats.graduated}
                 </Badge>
+                {pageGuide && (
+                  <Tooltip label="このページの使い方" withArrow>
+                    <ActionIcon
+                      variant="subtle"
+                      size="lg"
+                      radius="md"
+                      aria-label="このページの使い方を表示"
+                      onClick={requestGuideOpen}
+                      data-testid="page-onboarding-help"
+                      style={{ color: 'var(--text-secondary)' }}
+                    >
+                      <IconHelp size={20} stroke={1.8} />
+                    </ActionIcon>
+                  </Tooltip>
+                )}
               </Group>
 
               {pageActions && <div className="page-actions-container">{pageActions}</div>}
@@ -538,6 +561,7 @@ export function AppLayout({ children }: AppLayoutProps) {
           </AppShell.Main>
         </AppShell>
       </ContextMenuManager>
+      <PageOnboardingHost />
     </div>
   );
 }

--- a/frontend/src/components/onboarding/PageGuide.tsx
+++ b/frontend/src/components/onboarding/PageGuide.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { Drawer, Stack, Group, ThemeIcon, Text, Button, Divider, ScrollArea } from '@mantine/core';
+import type { PageGuide as PageGuideConfig } from '@/lib/onboarding/page-guides';
+
+interface PageGuideProps {
+  guide: PageGuideConfig;
+  opened: boolean;
+  onClose: () => void;
+}
+
+/**
+ * 「このページでできること」を一覧表示するヘルプドロワー。
+ * 初回訪問時の自動表示・ヘッダーの「?」からの手動表示の双方で利用する。
+ */
+export function PageGuide({ guide, opened, onClose }: PageGuideProps) {
+  return (
+    <Drawer
+      opened={opened}
+      onClose={onClose}
+      position="right"
+      size="md"
+      title={guide.title}
+      scrollAreaComponent={ScrollArea.Autosize}
+      data-testid="page-onboarding-drawer"
+    >
+      <Stack gap="lg">
+        {guide.intro && (
+          <Text size="sm" c="dimmed">
+            {guide.intro}
+          </Text>
+        )}
+
+        <Stack gap="md">
+          {guide.features.map((feature) => {
+            const Icon = feature.icon;
+            return (
+              <Group key={feature.title} gap="sm" wrap="nowrap" align="flex-start">
+                <ThemeIcon variant="light" size={38} radius="md">
+                  <Icon size={20} stroke={1.5} />
+                </ThemeIcon>
+                <Stack gap={2} style={{ flex: 1, minWidth: 0 }}>
+                  <Text size="sm" fw={700}>
+                    {feature.title}
+                  </Text>
+                  <Text size="sm" c="dimmed">
+                    {feature.description}
+                  </Text>
+                </Stack>
+              </Group>
+            );
+          })}
+        </Stack>
+
+        <Divider />
+
+        <Button onClick={onClose} fullWidth data-testid="page-onboarding-close">
+          了解しました
+        </Button>
+      </Stack>
+    </Drawer>
+  );
+}

--- a/frontend/src/components/onboarding/PageOnboardingHost.tsx
+++ b/frontend/src/components/onboarding/PageOnboardingHost.tsx
@@ -68,6 +68,8 @@ export function PageOnboardingHost() {
           '画面下のバーやメニューから各ページへ移動できます。ガイドのあるページでは右上の「?」からいつでも詳しい使い方を確認できます。',
         color: 'blue',
         autoClose: 8000,
+        // ヘッダー（高さ60px）と重ならないよう、この歓迎トーストだけ下げて表示する
+        style: { marginTop: 'calc(60px + var(--mantine-spacing-xs))' },
       });
     }
   }, [hydrated, initialized, isAuthenticated, userId, pathname, seen, markSeen]);

--- a/frontend/src/components/onboarding/PageOnboardingHost.tsx
+++ b/frontend/src/components/onboarding/PageOnboardingHost.tsx
@@ -53,6 +53,18 @@ export function PageOnboardingHost() {
   const welcomeHandledRef = useRef(false);
   const suppressPathRef = useRef<string | null>(null);
 
+  // ユーザーが切り替わったら歓迎・抑制・表示状態をリセットする。
+  // 同一セッションで「ログアウト→別ユーザーでログイン」した場合に、
+  // 新しいユーザーの歓迎処理が再評価されるようにする（この effect を最初に走らせる）。
+  const prevUserIdRef = useRef(userId);
+  useEffect(() => {
+    if (prevUserIdRef.current === userId) return;
+    prevUserIdRef.current = userId;
+    welcomeHandledRef.current = false;
+    suppressPathRef.current = null;
+    setOpened(false);
+  }, [userId]);
+
   useEffect(() => {
     if (welcomeHandledRef.current) return;
     if (!hydrated || !initialized || !isAuthenticated || !userId) return;

--- a/frontend/src/components/onboarding/PageOnboardingHost.tsx
+++ b/frontend/src/components/onboarding/PageOnboardingHost.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { usePathname } from 'next/navigation';
+import { notifications } from '@mantine/notifications';
+import { useAuth } from '@/lib/auth/store';
+import {
+  useOnboardingStore,
+  onboardingKey,
+  WELCOME_GUIDE_KEY,
+} from '@/lib/store/onboarding-store';
+import { findPageGuide } from '@/lib/onboarding/page-guides';
+import { PageGuide } from './PageGuide';
+
+/** persist による localStorage の復元完了を待つ */
+function useOnboardingHydrated(): boolean {
+  const [hydrated, setHydrated] = useState<boolean>(() =>
+    useOnboardingStore.persist.hasHydrated()
+  );
+
+  useEffect(() => {
+    const unsubscribe = useOnboardingStore.persist.onFinishHydration(() => setHydrated(true));
+    if (useOnboardingStore.persist.hasHydrated()) {
+      setHydrated(true);
+    }
+    return unsubscribe;
+  }, []);
+
+  return hydrated;
+}
+
+/**
+ * 全ページ共通のオンボーディング制御。AppLayout に1個だけ常駐させる。
+ * - 初回ログイン時は軽い歓迎ヒント（トースト）のみ表示
+ * - ガイド定義のあるページの初回訪問時にドロワーを自動表示
+ * - ヘッダーの「?」ボタン（requestOpen）からの手動表示にも対応
+ */
+export function PageOnboardingHost() {
+  const pathname = usePathname() ?? '/';
+  const { user, isAuthenticated, initialized } = useAuth();
+  const hydrated = useOnboardingHydrated();
+
+  const seen = useOnboardingStore((state) => state.seen);
+  const markSeen = useOnboardingStore((state) => state.markSeen);
+  const openToken = useOnboardingStore((state) => state.openToken);
+
+  const [opened, setOpened] = useState(false);
+
+  const guide = findPageGuide(pathname);
+  const userId = user?.id ?? null;
+
+  // 初回ログイン時は歓迎ヒントを優先し、着地ページの自動ガイドはこの回だけ見送る
+  const welcomeHandledRef = useRef(false);
+  const suppressPathRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (welcomeHandledRef.current) return;
+    if (!hydrated || !initialized || !isAuthenticated || !userId) return;
+
+    welcomeHandledRef.current = true;
+    const welcomeKey = onboardingKey(userId, WELCOME_GUIDE_KEY);
+    if (!seen[welcomeKey]) {
+      markSeen(welcomeKey);
+      suppressPathRef.current = pathname;
+      notifications.show({
+        title: 'MyCats へようこそ 🐈',
+        message:
+          '画面下のバーやメニューから各ページへ移動できます。ガイドのあるページでは右上の「?」からいつでも詳しい使い方を確認できます。',
+        color: 'blue',
+        autoClose: 8000,
+      });
+    }
+  }, [hydrated, initialized, isAuthenticated, userId, pathname, seen, markSeen]);
+
+  // ガイド定義のあるページの初回訪問時に自動表示
+  useEffect(() => {
+    if (!hydrated || !initialized || !isAuthenticated || !userId || !guide) return;
+    if (!welcomeHandledRef.current) return; // 歓迎処理を先に通す
+
+    if (suppressPathRef.current !== null) {
+      if (suppressPathRef.current === pathname) {
+        return; // 歓迎を表示した着地ページは今回見送る
+      }
+      suppressPathRef.current = null;
+    }
+
+    const guideKey = onboardingKey(userId, guide.pageKey);
+    if (!seen[guideKey]) {
+      markSeen(guideKey);
+      setOpened(true);
+    }
+  }, [hydrated, initialized, isAuthenticated, userId, guide, pathname, seen, markSeen]);
+
+  // ヘッダーの「?」ボタンからの手動表示
+  const lastOpenTokenRef = useRef(openToken);
+  useEffect(() => {
+    if (openToken === lastOpenTokenRef.current) return;
+    lastOpenTokenRef.current = openToken;
+    if (guide) {
+      setOpened(true);
+    }
+  }, [openToken, guide]);
+
+  if (!guide) {
+    return null;
+  }
+
+  return <PageGuide guide={guide} opened={opened} onClose={() => setOpened(false)} />;
+}

--- a/frontend/src/lib/onboarding/page-guides.ts
+++ b/frontend/src/lib/onboarding/page-guides.ts
@@ -1,0 +1,165 @@
+import {
+  IconLayoutGrid,
+  IconPaw,
+  IconHeart,
+  IconCalendarEvent,
+  IconAdjustments,
+  IconPlus,
+  IconSearch,
+  IconArrowsSort,
+  IconColumns,
+  IconEdit,
+  IconBabyCarriage,
+  IconClipboardCheck,
+  IconScale,
+  IconBan,
+  IconLayoutList,
+} from '@tabler/icons-react';
+
+/** Tabler アイコンコンポーネントの型（バージョン非依存に typeof で取得） */
+type GuideIcon = typeof IconPaw;
+
+export interface GuideFeature {
+  icon: GuideIcon;
+  /** 体言止めの短い見出し */
+  title: string;
+  /** 何ができるかの1文説明 */
+  description: string;
+}
+
+export interface PageGuide {
+  /** 表示済み管理に使う安定キー */
+  pageKey: string;
+  /** このガイドを表示するルートか判定する（pathname はクエリを含まない） */
+  match: (pathname: string) => boolean;
+  /** ドロワーの見出し */
+  title: string;
+  /** 導入文（任意） */
+  intro?: string;
+  /** このページでできることの一覧 */
+  features: GuideFeature[];
+}
+
+const guides: PageGuide[] = [
+  {
+    pageKey: 'home',
+    match: (pathname) => pathname === '/',
+    title: 'ホームでできること',
+    intro: 'よく使う情報の確認と、各機能への入口がまとまっています。',
+    features: [
+      {
+        icon: IconLayoutGrid,
+        title: '頭数サマリー',
+        description: 'オス・メス・子猫・卒業予定の頭数をひと目で確認できます。',
+      },
+      {
+        icon: IconPaw,
+        title: '新規猫登録',
+        description: '「新規猫登録」から猫を追加し、詳細情報を入力できます。',
+      },
+      {
+        icon: IconHeart,
+        title: '交配の予定',
+        description: '本日の交配予定や全体のスケジュール数を確認できます。',
+      },
+      {
+        icon: IconCalendarEvent,
+        title: 'ケアの未完了',
+        description: '対応が必要なケアスケジュールの件数を確認できます。',
+      },
+      {
+        icon: IconAdjustments,
+        title: 'カードの設定',
+        description: '右上の設定から、表示するカードや並び順をカスタマイズできます。',
+      },
+    ],
+  },
+  {
+    pageKey: 'cats',
+    match: (pathname) => pathname === '/cats',
+    title: '在舎猫の一覧でできること',
+    intro: '登録した猫の検索・編集・分類をまとめて行えます。',
+    features: [
+      {
+        icon: IconPlus,
+        title: '新規登録',
+        description: '右上の作成ボタンから新しい猫を登録できます。',
+      },
+      {
+        icon: IconLayoutList,
+        title: 'タブで分類',
+        description: 'オス・メス・子猫・育成中・卒業などのタブで絞り込んで表示できます。',
+      },
+      {
+        icon: IconSearch,
+        title: '検索・絞り込み',
+        description: '名前・毛色・品種で検索し、条件を組み合わせて絞り込めます。',
+      },
+      {
+        icon: IconArrowsSort,
+        title: '並び替え',
+        description: '名前順・年齢順・品種順・性別順など複数のパターンで並び替えできます。',
+      },
+      {
+        icon: IconColumns,
+        title: '列幅の調整',
+        description: '一覧の列幅をドラッグで調整でき、設定は自動で保存されます。',
+      },
+      {
+        icon: IconEdit,
+        title: '編集・削除・複製',
+        description: '各行から編集・削除・詳細表示・複製を行えます。',
+      },
+      {
+        icon: IconBabyCarriage,
+        title: '子猫の展開',
+        description: '母猫の行から子猫を展開して、親子関係を確認できます。',
+      },
+    ],
+  },
+  {
+    pageKey: 'breeding',
+    match: (pathname) => pathname === '/breeding',
+    title: '交配管理でできること',
+    intro: '交配から妊娠・出産・育成までを、フェーズごとに管理できます。',
+    features: [
+      {
+        icon: IconCalendarEvent,
+        title: '交配スケジュール',
+        description: 'カレンダーでオス・メスのペアと期間を設定し、実績を記録できます。',
+      },
+      {
+        icon: IconClipboardCheck,
+        title: '妊娠確認',
+        description: '交配後の妊娠の有無を確認し、出産予定へ進められます。',
+      },
+      {
+        icon: IconBabyCarriage,
+        title: '出産登録',
+        description: '出産日・頭数・死亡数を記録し、生存した子猫を自動登録できます。',
+      },
+      {
+        icon: IconScale,
+        title: '育成・発送管理',
+        description: '子猫の体重記録・タグ管理・発送先（里親・販売）を管理できます。',
+      },
+      {
+        icon: IconBan,
+        title: 'NG交配ルール',
+        description: '禁止する組み合わせを設定し、該当ペアの選択時に警告を表示します。',
+      },
+      {
+        icon: IconLayoutList,
+        title: 'フェーズ別タブ',
+        description: '交配・妊娠・出産・育成・体重・出荷の各フェーズをタブで切り替えられます。',
+      },
+    ],
+  },
+];
+
+export const PAGE_GUIDES: readonly PageGuide[] = guides;
+
+/** 現在のパスに対応するページガイドを返す。無ければ null */
+export function findPageGuide(pathname: string): PageGuide | null {
+  return PAGE_GUIDES.find((guide) => guide.match(pathname)) ?? null;
+}

--- a/frontend/src/lib/onboarding/page-guides.ts
+++ b/frontend/src/lib/onboarding/page-guides.ts
@@ -14,6 +14,36 @@ import {
   IconScale,
   IconBan,
   IconLayoutList,
+  IconList,
+  IconChevronDown,
+  IconCalendar,
+  IconCalendarPlus,
+  IconCheck,
+  IconEye,
+  IconEyeOff,
+  IconFilter,
+  IconStethoscope,
+  IconFolder,
+  IconStack,
+  IconTag,
+  IconRobot,
+  IconBinaryTree,
+  IconPrinter,
+  IconCopy,
+  IconUser,
+  IconUserPlus,
+  IconClipboard,
+  IconLock,
+  IconShield,
+  IconTrash,
+  IconBuildingSkyscraper,
+  IconCategory,
+  IconUpload,
+  IconPhoto,
+  IconFileExport,
+  IconFileImport,
+  IconDownload,
+  IconAlertCircle,
 } from '@tabler/icons-react';
 
 /** Tabler アイコンコンポーネントの型（バージョン非依存に typeof で取得） */
@@ -152,6 +182,364 @@ const guides: PageGuide[] = [
         icon: IconLayoutList,
         title: 'フェーズ別タブ',
         description: '交配・妊娠・出産・育成・体重・出荷の各フェーズをタブで切り替えられます。',
+      },
+    ],
+  },
+  {
+    pageKey: 'kittens',
+    match: (pathname) => pathname === '/kittens',
+    title: '子猫管理でできること',
+    intro: '出産した母猫ごとに、子猫の成長を記録・管理できます。',
+    features: [
+      {
+        icon: IconBabyCarriage,
+        title: '母猫グループ表示',
+        description: '出産した母猫ごとに子猫をまとめ、父猫や出産日を確認できます。',
+      },
+      {
+        icon: IconScale,
+        title: '体重記録',
+        description: '子猫ごと、またはグループ一括で体重を日時付きで記録できます。',
+      },
+      {
+        icon: IconList,
+        title: '子猫情報の管理',
+        description: '名前・性別・毛色・生年月日の登録/編集や、処分タイプ（訓練/販売/死亡）を管理できます。',
+      },
+      {
+        icon: IconCalendar,
+        title: '日齢の確認',
+        description: '生後日数を日・週・月で自動計算して確認できます。',
+      },
+      {
+        icon: IconChevronDown,
+        title: 'グループの展開',
+        description: 'グループを展開/折りたたみして、子猫リストの表示を切り替えられます。',
+      },
+    ],
+  },
+  {
+    pageKey: 'care',
+    match: (pathname) => pathname === '/care',
+    title: 'ケアスケジュールでできること',
+    intro: '猫ごとの定期的なケア予定を登録し、実施状況を管理できます。',
+    features: [
+      {
+        icon: IconCalendarPlus,
+        title: 'ケア予定の登録',
+        description: 'ケア名・対象猫・繰り返し（毎日/毎週/毎月/生後○日目など）を指定して登録できます。',
+      },
+      {
+        icon: IconCheck,
+        title: '完了の記録',
+        description: '実施したケアを完了にし、完了日・次回予定日・メモを残せます。',
+      },
+      {
+        icon: IconEdit,
+        title: '編集・削除',
+        description: '登録済みのケア予定を後から更新・削除できます。',
+      },
+      {
+        icon: IconLayoutGrid,
+        title: '統計カード',
+        description: 'ケア名ごとの対象頭数を統計カードでひと目で確認できます。',
+      },
+      {
+        icon: IconEye,
+        title: '詳細の確認',
+        description: '対象猫・予定日・繰り返し設定・登録者などの詳細を確認できます。',
+      },
+    ],
+  },
+  {
+    pageKey: 'medical-records',
+    match: (pathname) => pathname === '/medical-records',
+    title: '医療データでできること',
+    intro: '猫ごとの通院・診断・治療の記録をまとめて管理できます。',
+    features: [
+      {
+        icon: IconCalendarPlus,
+        title: '医療記録の登録',
+        description: '受診日・病院・症状・診断・治療計画・次回予定を登録できます。',
+      },
+      {
+        icon: IconFilter,
+        title: '猫で絞り込み',
+        description: '猫を選んで、その猫の医療記録だけを表示できます。',
+      },
+      {
+        icon: IconStethoscope,
+        title: '治療ステータス管理',
+        description: '治療の進行状況をステータスで管理できます。',
+      },
+      {
+        icon: IconEye,
+        title: '詳細の閲覧',
+        description: '基本情報・症状・診断/治療を詳細表示で確認できます。',
+      },
+      {
+        icon: IconList,
+        title: '一覧表示',
+        description: '受診日・猫名・診断・病院・ステータスを一覧で確認できます。',
+      },
+    ],
+  },
+  {
+    pageKey: 'tags',
+    match: (pathname) => pathname === '/tags',
+    title: 'タグ管理でできること',
+    intro: 'カテゴリ→グループ→タグの階層で、分類ラベルを整理できます。',
+    features: [
+      {
+        icon: IconFolder,
+        title: 'カテゴリ管理',
+        description: 'タグの大分類カテゴリを作成・編集・削除し、色やスコープを設定できます。',
+      },
+      {
+        icon: IconStack,
+        title: 'グループ管理',
+        description: 'カテゴリ内のグループを作成・編集・削除し、並び替えできます。',
+      },
+      {
+        icon: IconTag,
+        title: 'タグ管理',
+        description: 'グループ内のタグを作成・編集・削除し、並び替えできます。',
+      },
+      {
+        icon: IconRobot,
+        title: '自動化ルール',
+        description: '条件に応じてタグを自動で付与/削除するルールを作成・実行できます。',
+      },
+      {
+        icon: IconLayoutList,
+        title: '表示の切り替え',
+        description: 'カテゴリ階層・タグ一覧・自動化ルールのタブを切り替えられます。',
+      },
+      {
+        icon: IconEyeOff,
+        title: '非アクティブ表示',
+        description: '非アクティブな項目を表示/非表示で切り替えられます。',
+      },
+    ],
+  },
+  {
+    pageKey: 'pedigrees',
+    match: (pathname) => pathname === '/pedigrees',
+    title: '血統書データでできること',
+    intro: '血統書の登録・検索・家系図表示・PDF印刷までを行えます。',
+    features: [
+      {
+        icon: IconPlus,
+        title: '血統書の作成',
+        description: '猫の血統書データをフォームから登録できます。',
+      },
+      {
+        icon: IconSearch,
+        title: '検索・絞り込み',
+        description: '血統書番号・名前・性別・猫種・親情報などで検索できます。',
+      },
+      {
+        icon: IconBinaryTree,
+        title: '家系図の表示',
+        description: '選択した猫の2〜5世代の家系図を視覚的に表示できます。',
+      },
+      {
+        icon: IconPrinter,
+        title: 'PDF生成・印刷',
+        description: '各血統書をPDF化して開いたり、印刷したりできます。',
+      },
+      {
+        icon: IconAdjustments,
+        title: '印刷位置の設定',
+        description: 'PDF各項目の座標やフォントサイズをプレビューで調整できます。',
+      },
+      {
+        icon: IconCopy,
+        title: 'データの複製',
+        description: '既存の血統書をコピーして、新規登録に流用できます。',
+      },
+    ],
+  },
+  {
+    pageKey: 'staff-shifts',
+    match: (pathname) => pathname === '/staff/shifts',
+    title: 'スタッフシフトでできること',
+    intro: 'スタッフを登録し、カレンダー上で勤務シフトを組めます。',
+    features: [
+      {
+        icon: IconUserPlus,
+        title: 'スタッフ登録',
+        description: '名前・役職・カラー・出勤曜日・勤務時間を登録できます。',
+      },
+      {
+        icon: IconEdit,
+        title: '編集・削除',
+        description: '既存スタッフの情報を更新・削除できます。',
+      },
+      {
+        icon: IconCalendarEvent,
+        title: 'ドラッグでシフト作成',
+        description: 'スタッフをカレンダーへドラッグして、指定日にシフトを作成できます。',
+      },
+      {
+        icon: IconCalendarPlus,
+        title: 'テンプレート一括入力',
+        description: '出勤曜日テンプレートから、表示期間内のシフトを一括生成できます。',
+      },
+      {
+        icon: IconClipboard,
+        title: 'シフトのコピー',
+        description: '日付ごとのシフトをテキスト化して、クリップボードにコピーできます。',
+      },
+    ],
+  },
+  {
+    pageKey: 'tenants',
+    match: (pathname) => pathname === '/tenants',
+    title: 'ユーザー設定でできること',
+    intro: '自分のプロフィールと、テナント内ユーザーの権限を管理できます。',
+    features: [
+      {
+        icon: IconUser,
+        title: 'プロフィール編集',
+        description: 'ユーザー名・メールアドレスを変更できます。',
+      },
+      {
+        icon: IconLock,
+        title: 'パスワード変更',
+        description: '現在のパスワードと新しいパスワードを入力して変更できます。',
+      },
+      {
+        icon: IconUserPlus,
+        title: 'ユーザー招待',
+        description: 'テナント内に新規ユーザーを招待し、ロールを指定できます（管理者）。',
+      },
+      {
+        icon: IconShield,
+        title: 'ロール変更',
+        description: 'テナント内ユーザーの権限（一般/管理者）を変更できます。',
+      },
+      {
+        icon: IconTrash,
+        title: 'ユーザー削除',
+        description: 'テナント内のユーザーを削除できます。',
+      },
+      {
+        icon: IconBuildingSkyscraper,
+        title: 'テナント管理',
+        description: 'テナントの作成・編集・削除や管理者の招待ができます（スーパー管理者）。',
+      },
+    ],
+  },
+  {
+    pageKey: 'gallery',
+    match: (pathname) => pathname === '/gallery',
+    title: 'ギャラリーでできること',
+    intro: '子猫・父猫・母猫・卒業猫の写真や動画を一元管理できます。',
+    features: [
+      {
+        icon: IconCategory,
+        title: 'カテゴリ切り替え',
+        description: '子猫・父猫・母猫・卒業猫のタブで表示を切り替えられます。',
+      },
+      {
+        icon: IconUpload,
+        title: '写真・動画の追加',
+        description: '画像ファイルやYouTube動画URLを、基本情報付きで追加できます。',
+      },
+      {
+        icon: IconEdit,
+        title: '情報の編集',
+        description: '各エントリの名前・性別・毛色・メモなどを編集できます。',
+      },
+      {
+        icon: IconTrash,
+        title: '削除',
+        description: '不要なエントリを確認ダイアログ付きで削除できます。',
+      },
+      {
+        icon: IconPhoto,
+        title: '拡大表示',
+        description: '写真や動画をライトボックスでフルスクリーン閲覧できます。',
+      },
+    ],
+  },
+  {
+    pageKey: 'more',
+    match: (pathname) => pathname === '/more',
+    title: 'その他の機能でできること',
+    intro: 'データの入出力や印刷テンプレートの設定にアクセスできます。',
+    features: [
+      {
+        icon: IconPrinter,
+        title: '印刷テンプレート管理',
+        description: '血統書など各種書類の印刷レイアウトを設定・カスタマイズできます。',
+      },
+      {
+        icon: IconFileExport,
+        title: 'データエクスポート',
+        description: '猫の情報などをCSV/PDFで出力して外部で利用できます。',
+      },
+      {
+        icon: IconFileImport,
+        title: 'データインポート',
+        description: 'CSVファイルから猫の情報を一括登録できます。',
+      },
+    ],
+  },
+  {
+    pageKey: 'export',
+    match: (pathname) => pathname === '/export',
+    title: 'エクスポートでできること',
+    intro: '登録済みデータをファイルに書き出して、外部で活用できます。',
+    features: [
+      {
+        icon: IconFileExport,
+        title: 'データの出力',
+        description: '猫・血統書・ケア・タグのデータをファイルに書き出せます。',
+      },
+      {
+        icon: IconDownload,
+        title: '形式の選択',
+        description: 'CSV（表計算向け）かJSON（構造保持）を選んでダウンロードできます。',
+      },
+      {
+        icon: IconCalendar,
+        title: '期間で絞り込み',
+        description: '開始日・終了日を指定して、該当期間のデータだけ出力できます。',
+      },
+    ],
+  },
+  {
+    pageKey: 'import',
+    match: (pathname) => pathname === '/import',
+    title: 'インポートでできること',
+    intro: 'CSVファイルから、データをまとめて取り込めます。',
+    features: [
+      {
+        icon: IconList,
+        title: '対象の選択',
+        description: '猫・血統書・タグから、インポートする対象を選べます。',
+      },
+      {
+        icon: IconUpload,
+        title: 'ファイルのアップロード',
+        description: 'CSVをドラッグ＆ドロップ（最大5MB）で読み込めます。',
+      },
+      {
+        icon: IconEye,
+        title: '内容の確認',
+        description: '件数・カラム名・先頭データをプレビューで検証できます。',
+      },
+      {
+        icon: IconFileImport,
+        title: '取り込みの実行',
+        description: '成功/失敗の件数と進捗を確認しながらインポートできます。',
+      },
+      {
+        icon: IconAlertCircle,
+        title: 'エラーの確認',
+        description: 'インポート失敗時に、エラーの詳細を一覧で確認できます。',
       },
     ],
   },

--- a/frontend/src/lib/store/onboarding-store.ts
+++ b/frontend/src/lib/store/onboarding-store.ts
@@ -1,0 +1,56 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+/** 初回ログインの歓迎ヒントに使う擬似ガイドキー */
+export const WELCOME_GUIDE_KEY = '__welcome__';
+
+/** ユーザーID とガイドキーから localStorage 用の複合キーを作る */
+export function onboardingKey(userId: string, guideKey: string): string {
+  return `${userId}::${guideKey}`;
+}
+
+interface OnboardingState {
+  /** 表示済みフラグ。キーは `${userId}::${guideKey}`（localStorage に永続化） */
+  seen: Record<string, boolean>;
+  /** ヘッダーの「?」ボタンからの手動表示要求トークン（永続化しない） */
+  openToken: number;
+}
+
+interface OnboardingActions {
+  /** 指定キーのガイドを表示済みにする */
+  markSeen: (key: string) => void;
+  /** 指定ユーザーの表示済みフラグをすべて解除する（再表示・デバッグ用） */
+  resetForUser: (userId: string) => void;
+  /** 現在のページガイドの手動再表示を要求する */
+  requestOpen: () => void;
+}
+
+type OnboardingStore = OnboardingState & OnboardingActions;
+
+export const useOnboardingStore = create<OnboardingStore>()(
+  persist(
+    (set) => ({
+      seen: {},
+      openToken: 0,
+      markSeen: (key) =>
+        set((state) => (state.seen[key] ? state : { seen: { ...state.seen, [key]: true } })),
+      resetForUser: (userId) =>
+        set((state) => {
+          const prefix = `${userId}::`;
+          const next: Record<string, boolean> = {};
+          for (const [key, value] of Object.entries(state.seen)) {
+            if (!key.startsWith(prefix)) {
+              next[key] = value;
+            }
+          }
+          return { seen: next };
+        }),
+      requestOpen: () => set((state) => ({ openToken: state.openToken + 1 })),
+    }),
+    {
+      name: 'mycats-onboarding',
+      // openToken は端末セッション限りの一時値なので永続化しない
+      partialize: (state) => ({ seen: state.seen }),
+    }
+  )
+);


### PR DESCRIPTION
## 概要

初めてアプリを使う人向けのオンボーディングを追加しました。グローバルナビは軽く案内し、各ページで「このページでできること」を本格的に説明する方針です。

## 実装内容

- **各ページ初回訪問時**に「このページでできること」を Mantine `Drawer` でアイコン付き箇条書きで自動表示
- **ルートごとの `page-guides` レジストリ**（今回は ホーム / 在舎猫 / 交配 の3ページを実装。`page-guides.ts` に追記するだけで対応ページを拡張可能）
- **初回ログイン時**は軽い歓迎トースト1回のみ（過剰表示を回避）
- ヘッダーの **「?」ボタン**からいつでも手動再表示
- 完了状態は **`user × ページ` 単位で localStorage に保存**（Zustand persist）。Backend 変更・マイグレーション不要

## 設計判断

- 説明パネル方式を採用し、スポットライト系ライブラリ（driver.js 等）は不使用 → **新規依存ゼロ**
- 中央集約方式: `PageOnboardingHost` を `AppLayout` に1個常駐させ、**各ページ本体は無改変**（最小差分）

## 品質ゲート

- `tsc --noEmit` … エラーなし（厳格な型安全ポリシー準拠）
- `eslint --max-warnings 0` … 警告ゼロ
- `next build` … コンパイル成功・全26ページ生成

## 動作確認メモ

再テスト時は localStorage の `mycats-onboarding` を削除するか、store の `resetForUser(userId)` で初回状態に戻せます。

## 残作業（後続）

子猫 / ケア / 医療 / タグ / 血統書 / シフト / ユーザー設定 / ギャラリー / その他 / エクスポート・インポート の各ページガイドを順次追加予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)