### PR TITLE
fix(breeding): 交配表のオス列をサーバーから復元しデバイス間同期

### DIFF
--- a/frontend/e2e/breeding-active-males.spec.ts
+++ b/frontend/e2e/breeding-active-males.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * 交配表のオス列同期 E2E テスト
+ *
+ * 回帰防止: 交配表のオス列は localStorage ではなくサーバーの交配スケジュールから
+ * 復元され、`/breeding/schedules` の返却順に依存せず createdAt 昇順（= ペア成立の瞬間、
+ * 全デバイスで同一順序）で並ぶことを検証する。
+ *
+ * 前提: 認証は setup プロジェクト（storageState）を再利用。
+ * /cats と /breeding/schedules はこのテスト内でモックし、localStorage は空（別デバイス相当）の状態で検証する。
+ */
+
+import { test, expect } from './fixtures/base';
+
+const cats = [
+  { id: 'e2e-male-1', name: 'E2EオスA', gender: 'MALE', isInHouse: true, birthDate: '2022-01-01' },
+  { id: 'e2e-male-2', name: 'E2EオスB', gender: 'MALE', isInHouse: true, birthDate: '2022-01-01' },
+  { id: 'e2e-male-3', name: 'E2EオスC', gender: 'MALE', isInHouse: true, birthDate: '2022-01-01' },
+  { id: 'e2e-female-1', name: 'E2EメスX', gender: 'FEMALE', isInHouse: true, birthDate: '2022-01-01' },
+];
+
+function makeSchedule(id: string, maleId: string, maleName: string, createdAt: string) {
+  return {
+    id,
+    maleId,
+    femaleId: 'e2e-female-1',
+    startDate: '2026-06-10',
+    duration: 3,
+    status: 'SCHEDULED',
+    recordedBy: 'e2e',
+    createdAt,
+    updatedAt: createdAt,
+    male: { id: maleId, name: maleName },
+    female: { id: 'e2e-female-1', name: 'E2EメスX' },
+    checks: [],
+  };
+}
+
+// 配列順はわざと A, C, B。createdAt 昇順は B(08:00) → A(10:00) → C(12:00)。
+const schedules = [
+  makeSchedule('e2e-s-a', 'e2e-male-1', 'E2EオスA', '2026-06-20T10:00:00.000Z'),
+  makeSchedule('e2e-s-c', 'e2e-male-3', 'E2EオスC', '2026-06-20T12:00:00.000Z'),
+  makeSchedule('e2e-s-b', 'e2e-male-2', 'E2EオスB', '2026-06-20T08:00:00.000Z'),
+];
+
+test.describe('交配表のオス列同期', () => {
+  test('localStorage が空でも /breeding/schedules の返却順に依存せず createdAt 昇順でオス列が復元される', async ({ page }) => {
+    // 猫一覧と交配スケジュールをモック（別 API は実バックエンドに委ねる）
+    await page.route(/\/api\/v1\/cats(\?|$)/, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          data: cats,
+          meta: { total: cats.length, page: 1, limit: 1000, totalPages: 1 },
+        }),
+      }),
+    );
+    await page.route(/\/api\/v1\/breeding\/schedules/, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, data: schedules }),
+      }),
+    );
+
+    await page.goto('/breeding');
+    await page.waitForLoadState('networkidle');
+
+    // サーバー由来のオス列ヘッダが描画されるまで待つ
+    await expect(page.getByText('E2EオスA').first()).toBeVisible({ timeout: 15000 });
+
+    // テーブルヘッダのオス名を DOM 順で取得
+    const order = await page.evaluate(() => {
+      const names = ['E2EオスA', 'E2EオスB', 'E2EオスC'];
+      const result: string[] = [];
+      for (const th of Array.from(document.querySelectorAll('th'))) {
+        const text = (th.textContent || '').trim();
+        for (const name of names) {
+          if (text.includes(name) && !result.includes(name)) {
+            result.push(name);
+          }
+        }
+      }
+      return result;
+    });
+
+    // 返却順(A,C,B)ではなく createdAt 昇順(B,A,C)で並ぶこと
+    expect(order).toEqual(['E2EオスB', 'E2EオスA', 'E2EオスC']);
+  });
+});

--- a/frontend/src/app/breeding/hooks/useBreedingSchedule.ts
+++ b/frontend/src/app/breeding/hooks/useBreedingSchedule.ts
@@ -254,6 +254,8 @@ export function useBreedingSchedule(allCats: Cat[] = []): UseBreedingScheduleRet
   const activeMales = useMemo<Cat[]>(() => {
     const ordered: Cat[] = [];
     const seen = new Set<string>();
+    // 猫数が多い（limit:1000）ケースでも O(1) で解決できるよう Map 化する
+    const catById = new Map(allCats.map((c) => [c.id, c] as const));
 
     const serverSchedules = schedulesQuery.data?.data ?? [];
     const sorted = [...serverSchedules].sort((a, b) => {
@@ -263,7 +265,7 @@ export function useBreedingSchedule(allCats: Cat[] = []): UseBreedingScheduleRet
     for (const schedule of sorted) {
       const maleId = schedule.maleId;
       if (!maleId || seen.has(maleId)) continue;
-      const cat = allCats.find((c) => c.id === maleId);
+      const cat = catById.get(maleId);
       if (cat) {
         seen.add(maleId);
         ordered.push(cat);
@@ -287,14 +289,15 @@ export function useBreedingSchedule(allCats: Cat[] = []): UseBreedingScheduleRet
 
   // オス猫削除（ローカル＋ひも付くサーバーのスケジュールも削除して全デバイスから消す）
   const removeMale = useCallback(async (maleId: string) => {
-    setLocalActiveMales((prev) => prev.filter((m) => m.id !== maleId));
-
+    // ひも付くサーバーのスケジュールを先に削除する。
+    // 失敗は握りつぶさず呼び出し側へ伝播させ、その場合ローカル状態は更新しない（同期不整合を防ぐ）。
     const serverIds = (schedulesQuery.data?.data ?? [])
       .filter((s) => s.maleId === maleId)
       .map((s) => s.id);
-    await Promise.all(
-      serverIds.map((id) => deleteScheduleMutation.mutateAsync(id).catch(() => undefined)),
-    );
+    await Promise.all(serverIds.map((id) => deleteScheduleMutation.mutateAsync(id)));
+
+    // サーバー削除が成功した後にローカル状態を更新する
+    setLocalActiveMales((prev) => prev.filter((m) => m.id !== maleId));
 
     // ローカルのカレンダーエントリ（当該オス分）も除去
     setBreedingSchedule((prev) => {

--- a/frontend/src/app/breeding/hooks/useBreedingSchedule.ts
+++ b/frontend/src/app/breeding/hooks/useBreedingSchedule.ts
@@ -39,14 +39,13 @@ export interface UseBreedingScheduleReturn {
   // アクション
   setBreedingSchedule: React.Dispatch<React.SetStateAction<Record<string, BreedingScheduleEntry>>>;
   setMatingChecks: React.Dispatch<React.SetStateAction<Record<string, number>>>;
-  setActiveMales: React.Dispatch<React.SetStateAction<Cat[]>>;
   setSelectedYear: React.Dispatch<React.SetStateAction<number>>;
   setSelectedMonth: React.Dispatch<React.SetStateAction<number>>;
   setDefaultDuration: React.Dispatch<React.SetStateAction<number>>;
   
   // ヘルパー関数
   addMale: (male: Cat) => void;
-  removeMale: (maleId: string) => void;
+  removeMale: (maleId: string) => Promise<void>;
   getMatingCheckCount: (maleId: string, femaleId: string, date: string) => number;
   addMatingCheck: (maleId: string, femaleId: string, date: string) => void;
   clearScheduleData: () => void;
@@ -114,7 +113,7 @@ function convertServerChecksToLocal(
   return result;
 }
 
-export function useBreedingSchedule(): UseBreedingScheduleReturn {
+export function useBreedingSchedule(allCats: Cat[] = []): UseBreedingScheduleReturn {
   // hydration guard: 初回マウント時に localStorage から読み込むまで保存を抑制
   const hydratedRef = useRef(false);
   const mountCountRef = useRef(0);
@@ -122,7 +121,8 @@ export function useBreedingSchedule(): UseBreedingScheduleReturn {
   const [selectedMonth, setSelectedMonth] = useState(new Date().getMonth() + 1);
   const [selectedYear, setSelectedYear] = useState(new Date().getFullYear());
   const [breedingSchedule, setBreedingSchedule] = useState<Record<string, BreedingScheduleEntry>>({});
-  const [activeMales, setActiveMales] = useState<Cat[]>([]);
+  // ローカルで追加したオス（まだサーバーにペアが無い単独オスの作業用リスト）
+  const [localActiveMales, setLocalActiveMales] = useState<Cat[]>([]);
   const [defaultDuration, setDefaultDuration] = useState<number>(1);
   const [matingChecks, setMatingChecks] = useState<Record<string, number>>({});
   const [isSyncing, setIsSyncing] = useState(false);
@@ -141,7 +141,7 @@ export function useBreedingSchedule(): UseBreedingScheduleReturn {
         const storedActiveMales = localStorage.getItem(STORAGE_KEYS.ACTIVE_MALES);
         if (storedActiveMales) {
           const parsed = JSON.parse(storedActiveMales) as Cat[];
-          setActiveMales(parsed);
+          setLocalActiveMales(parsed);
         }
 
         const storedDefaultDuration = localStorage.getItem(STORAGE_KEYS.DEFAULT_DURATION);
@@ -232,7 +232,7 @@ export function useBreedingSchedule(): UseBreedingScheduleReturn {
       if (!hydratedRef.current) return;
 
       try {
-        localStorage.setItem(STORAGE_KEYS.ACTIVE_MALES, JSON.stringify(activeMales));
+        localStorage.setItem(STORAGE_KEYS.ACTIVE_MALES, JSON.stringify(localActiveMales));
         localStorage.setItem(STORAGE_KEYS.DEFAULT_DURATION, defaultDuration.toString());
         localStorage.setItem(STORAGE_KEYS.SELECTED_YEAR, selectedYear.toString());
         localStorage.setItem(STORAGE_KEYS.SELECTED_MONTH, selectedMonth.toString());
@@ -246,17 +246,67 @@ export function useBreedingSchedule(): UseBreedingScheduleReturn {
     };
 
     saveToStorage();
-  }, [activeMales, defaultDuration, selectedYear, selectedMonth, breedingSchedule, matingChecks]);
+  }, [localActiveMales, defaultDuration, selectedYear, selectedMonth, breedingSchedule, matingChecks]);
 
-  // オス猫追加
+  // 表示用 activeMales を導出する。
+  // サーバーのスケジュールに登場するオスを createdAt 昇順（= ペア成立の瞬間、全デバイスで同一順序）に並べ、
+  // まだサーバーに無いローカル追加分（メス未投入の単独オス）を末尾に付ける。
+  const activeMales = useMemo<Cat[]>(() => {
+    const ordered: Cat[] = [];
+    const seen = new Set<string>();
+
+    const serverSchedules = schedulesQuery.data?.data ?? [];
+    const sorted = [...serverSchedules].sort((a, b) => {
+      const byCreatedAt = (a.createdAt ?? '').localeCompare(b.createdAt ?? '');
+      return byCreatedAt !== 0 ? byCreatedAt : a.id.localeCompare(b.id);
+    });
+    for (const schedule of sorted) {
+      const maleId = schedule.maleId;
+      if (!maleId || seen.has(maleId)) continue;
+      const cat = allCats.find((c) => c.id === maleId);
+      if (cat) {
+        seen.add(maleId);
+        ordered.push(cat);
+      }
+    }
+
+    for (const male of localActiveMales) {
+      if (!seen.has(male.id)) {
+        seen.add(male.id);
+        ordered.push(male);
+      }
+    }
+
+    return ordered;
+  }, [schedulesQuery.data, allCats, localActiveMales]);
+
+  // オス猫追加（ローカル作業リストに追加。メスを入れた時点でサーバー保存→全デバイス同期）
   const addMale = useCallback((male: Cat) => {
-    setActiveMales((prev) => [...prev, male]);
+    setLocalActiveMales((prev) => (prev.some((m) => m.id === male.id) ? prev : [...prev, male]));
   }, []);
 
-  // オス猫削除
-  const removeMale = useCallback((maleId: string) => {
-    setActiveMales((prev) => prev.filter((m) => m.id !== maleId));
-  }, []);
+  // オス猫削除（ローカル＋ひも付くサーバーのスケジュールも削除して全デバイスから消す）
+  const removeMale = useCallback(async (maleId: string) => {
+    setLocalActiveMales((prev) => prev.filter((m) => m.id !== maleId));
+
+    const serverIds = (schedulesQuery.data?.data ?? [])
+      .filter((s) => s.maleId === maleId)
+      .map((s) => s.id);
+    await Promise.all(
+      serverIds.map((id) => deleteScheduleMutation.mutateAsync(id).catch(() => undefined)),
+    );
+
+    // ローカルのカレンダーエントリ（当該オス分）も除去
+    setBreedingSchedule((prev) => {
+      const next: Record<string, BreedingScheduleEntry> = {};
+      for (const [key, entry] of Object.entries(prev)) {
+        if (entry.maleId !== maleId) {
+          next[key] = entry;
+        }
+      }
+      return next;
+    });
+  }, [schedulesQuery.data, deleteScheduleMutation]);
 
   // 交配チェック回数を取得
   const getMatingCheckCount = useCallback((maleId: string, femaleId: string, date: string): number => {
@@ -374,7 +424,6 @@ export function useBreedingSchedule(): UseBreedingScheduleReturn {
     isSyncing,
     setBreedingSchedule,
     setMatingChecks,
-    setActiveMales,
     setSelectedYear,
     setSelectedMonth,
     setDefaultDuration,

--- a/frontend/src/app/breeding/page.tsx
+++ b/frontend/src/app/breeding/page.tsx
@@ -70,7 +70,11 @@ import { calculateAgeInMonths } from './utils';
 
 export default function BreedingPage() {
   const { setPageHeader } = usePageHeader();
-  
+
+  // 全猫リスト（交配表のオス列をサーバーのスケジュールから復元・解決するのに使用）
+  const catsQuery = useGetCats({ limit: 1000 }, { enabled: true });
+  const { data: catsResponse } = catsQuery;
+
   // カスタムフックから状態を取得
   const {
     breedingSchedule,
@@ -90,7 +94,7 @@ export default function BreedingPage() {
     createScheduleOnServer,
     updateScheduleOnServer,
     deleteScheduleOnServer,
-  } = useBreedingSchedule();
+  } = useBreedingSchedule(catsResponse?.data ?? []);
 
   const [activeTab, setActiveTab] = useState('schedule');
   const [isFullscreen] = useState(false);
@@ -154,8 +158,6 @@ export default function BreedingPage() {
   });
 
   // API hooks
-  const catsQuery = useGetCats({ limit: 1000 }, { enabled: true });
-  const { data: catsResponse } = catsQuery;
   const tagCategoriesQuery = useGetTagCategories();
   const ngRulesQuery = useGetBreedingNgRules();
   const { data: ngRulesResponse, isLoading: isNgRulesLoading, isFetching: isNgRulesFetching, error: ngRulesError } = ngRulesQuery;
@@ -234,7 +236,19 @@ export default function BreedingPage() {
 
   // オス猫削除
   const handleRemoveMale = (maleId: string) => {
-    removeMale(maleId);
+    // サーバー保存済み（ペアあり）のオスは、ひも付く交配スケジュールも消えるため確認する
+    const hasServerData = Object.values(breedingSchedule).some(
+      (entry) => entry.maleId === maleId && entry.serverId,
+    );
+    if (
+      hasServerData &&
+      !window.confirm('このオスと、ひも付く交配スケジュールをすべて削除します。よろしいですか？')
+    ) {
+      return;
+    }
+    removeMale(maleId).catch(() => {
+      notifications.show({ title: 'エラー', message: 'オスの削除に失敗しました', color: 'red' });
+    });
     setSelectedMaleForEdit(null);
   };
 


### PR DESCRIPTION
## 概要

交配管理ページの交配表で「オスを追加→メスを追加」した内容が**別デバイスに反映されない**問題を修正します。

## 原因（調査結果）

- 交配表のオス列は `activeMales`（**localStorage のみ**）から描画されていた（`BreedingScheduleTab` の `activeMales.map(...)`）。
- そのため別デバイスでは**オス列が空 → サーバー保存済みのペアリングも表に出ない** → 「全部消えて見える」状態だった。
- オス名クリックで出る「**保存**」ボタンは、実は `setSelectedMaleForEdit(null)`（編集パネルを閉じるだけ）の **no-op** で、何も保存していなかった。
- 一方、ペアリング（オス×メス）は**メスを入れた瞬間に `POST /breeding/schedules` で既にサーバー保存**されている。

## 修正（フロントのみ・バックエンド変更なし・マイグレ無し）

- `activeMales` を **サーバーのスケジュールに登場するオス（`createdAt` 昇順）∪ ローカル追加分** から導出。
  - `createdAt`（ペア成立の瞬間・サーバー側で一意）順なので、**どのデバイスで読み込んでも表示順序が一致**する。
  - ペア成立済みのオスとその内容が全デバイスで表示される。
- `addMale` はローカル作業リストに追加（メス投入時にサーバー保存→同期する既存フローは維持）。
- `removeMale` はローカル＋**ひも付くサーバースケジュールも削除**して全デバイスから消す。ペアあり時は確認ダイアログ＋エラーハンドリングを追加。
- 内部専用だった `setActiveMales` を公開 API から除去。

> 注: 「まだ一度もメスを入れていない単独オスの列」は端末ローカルのまま（メスを入れた時点でサーバー保存→同期）。これは合意済みのスコープです。

## 検証

- Playwright で **localStorage 空（＝別デバイス相当）** の状態で `/breeding` を開き、`/breeding/schedules` を**順不同**で返すモックに対し、オス列が **`createdAt` 順**（オスB→オスA→オスC）で復元されること、ペアリングがカレンダーに描画されること、pageerror が無いことを確認。
- 型チェック / `eslint --max-warnings 0` / `next build`（全26ページ生成）グリーン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)