### PR TITLE
feat: フィードバック送信ウィジェットを追加（管理者宛メール）

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -20,6 +20,7 @@ import { SecurityMiddleware } from "./common/middleware/security.middleware";
 import { DisplayPreferencesModule } from "./display-preferences/display-preferences.module";
 import { EmailModule } from "./email/email.module";
 import { ExportModule } from "./export/export.module";
+import { FeedbackModule } from "./feedback/feedback.module";
 import { GalleryModule } from "./gallery/gallery.module";
 import { GalleryUploadModule } from "./gallery-upload/gallery-upload.module";
 import { GraduationModule } from "./graduation/graduation.module";
@@ -127,6 +128,7 @@ const sanitizeLevel = (value: unknown): LogLevel => {
     GalleryModule,
     EmailModule,
     ExportModule,
+    FeedbackModule,
     ImportModule,
   ],
   controllers: [MasterDataController],

--- a/backend/src/feedback/dto/create-feedback.dto.ts
+++ b/backend/src/feedback/dto/create-feedback.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+
+/**
+ * フィードバック送信 DTO
+ */
+export class CreateFeedbackDto {
+  @ApiProperty({ description: 'フィードバック本文（最大200文字）', maxLength: 200 })
+  @IsString()
+  @IsNotEmpty({ message: 'フィードバック本文を入力してください' })
+  @MaxLength(200, { message: 'フィードバックは200文字以内で入力してください' })
+  message: string;
+}

--- a/backend/src/feedback/feedback.controller.spec.ts
+++ b/backend/src/feedback/feedback.controller.spec.ts
@@ -1,0 +1,34 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+
+import { FeedbackController } from './feedback.controller';
+import { FeedbackService } from './feedback.service';
+
+describe('FeedbackController', () => {
+  let controller: FeedbackController;
+  const mockFeedbackService = { submit: jest.fn() };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [FeedbackController],
+      providers: [{ provide: FeedbackService, useValue: mockFeedbackService }],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+    controller = module.get<FeedbackController>(FeedbackController);
+  });
+
+  it('service.submit に委譲し、結果を ApiResponse.success で包んで返す', async () => {
+    mockFeedbackService.submit.mockResolvedValue({ sent: true });
+
+    const user = { userId: 'u1', email: 'user@example.com' };
+    const res = await controller.submit({ message: 'テスト' }, user);
+
+    expect(mockFeedbackService.submit).toHaveBeenCalledWith({ message: 'テスト' }, user);
+    expect(res.success).toBe(true);
+    expect(res.data).toEqual({ sent: true });
+  });
+});

--- a/backend/src/feedback/feedback.controller.ts
+++ b/backend/src/feedback/feedback.controller.ts
@@ -1,0 +1,32 @@
+import { Body, Controller, HttpCode, HttpStatus, Post, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+
+import type { RequestUser } from '../auth/auth.types';
+import { GetUser } from '../auth/get-user.decorator';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { ApiResponse } from '../common/dto/api-response.dto';
+
+import { CreateFeedbackDto } from './dto/create-feedback.dto';
+import { FeedbackService } from './feedback.service';
+
+@ApiTags('feedback')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('feedback')
+export class FeedbackController {
+  constructor(private readonly feedbackService: FeedbackService) {}
+
+  /**
+   * フィードバックを送信する（管理者宛メール）
+   */
+  @Post()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'フィードバックを送信（管理者宛メール）' })
+  async submit(
+    @Body() dto: CreateFeedbackDto,
+    @GetUser() user?: RequestUser,
+  ): Promise<ApiResponse<{ sent: boolean }>> {
+    const result = await this.feedbackService.submit(dto, user);
+    return ApiResponse.success(result);
+  }
+}

--- a/backend/src/feedback/feedback.module.ts
+++ b/backend/src/feedback/feedback.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+
+import { EmailModule } from '../email/email.module';
+
+import { FeedbackController } from './feedback.controller';
+import { FeedbackService } from './feedback.service';
+
+/**
+ * フィードバック機能を提供するモジュール。
+ * 既存の EmailModule を再利用して管理者宛にメール送信する（DB 保存なし）。
+ */
+@Module({
+  imports: [EmailModule],
+  controllers: [FeedbackController],
+  providers: [FeedbackService],
+})
+export class FeedbackModule {}

--- a/backend/src/feedback/feedback.service.spec.ts
+++ b/backend/src/feedback/feedback.service.spec.ts
@@ -1,0 +1,71 @@
+import { ConfigService } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { EmailService } from '../email/email.service';
+
+import { FeedbackService } from './feedback.service';
+
+describe('FeedbackService', () => {
+  let service: FeedbackService;
+  const mockEmailService = { sendEmail: jest.fn() };
+  const mockConfigService = { get: jest.fn() };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FeedbackService,
+        { provide: EmailService, useValue: mockEmailService },
+        { provide: ConfigService, useValue: mockConfigService },
+      ],
+    }).compile();
+    service = module.get<FeedbackService>(FeedbackService);
+  });
+
+  it('ADMIN_EMAIL が未設定なら sent=false を返し、メールを送らない', async () => {
+    mockConfigService.get.mockReturnValue(undefined);
+
+    const result = await service.submit({ message: 'テストフィードバック' });
+
+    expect(result).toEqual({ sent: false });
+    expect(mockEmailService.sendEmail).not.toHaveBeenCalled();
+  });
+
+  it('ADMIN_EMAIL 設定ありなら ADMIN_EMAIL 宛に sendEmail し、結果を sent に反映する', async () => {
+    mockConfigService.get.mockReturnValue('admin@example.com');
+    mockEmailService.sendEmail.mockResolvedValue({ success: true });
+
+    const result = await service.submit(
+      { message: 'ご意見です' },
+      { userId: 'u1', email: 'user@example.com' },
+    );
+
+    expect(result).toEqual({ sent: true });
+    expect(mockEmailService.sendEmail).toHaveBeenCalledTimes(1);
+    const payload = mockEmailService.sendEmail.mock.calls[0][0];
+    expect(payload.to).toBe('admin@example.com');
+    expect(payload.replyTo).toBe('user@example.com');
+    expect(payload.text).toContain('ご意見です');
+  });
+
+  it('メール送信が失敗したら sent=false を返す', async () => {
+    mockConfigService.get.mockReturnValue('admin@example.com');
+    mockEmailService.sendEmail.mockResolvedValue({ success: false });
+
+    const result = await service.submit({ message: 'テスト' });
+
+    expect(result).toEqual({ sent: false });
+    expect(mockEmailService.sendEmail).toHaveBeenCalledTimes(1);
+  });
+
+  it('HTML 本文はユーザー入力をエスケープする', async () => {
+    mockConfigService.get.mockReturnValue('admin@example.com');
+    mockEmailService.sendEmail.mockResolvedValue({ success: true });
+
+    await service.submit({ message: '<script>alert(1)</script>' });
+
+    const payload = mockEmailService.sendEmail.mock.calls[0][0];
+    expect(payload.html).toContain('&lt;script&gt;');
+    expect(payload.html).not.toContain('<script>');
+  });
+});

--- a/backend/src/feedback/feedback.service.ts
+++ b/backend/src/feedback/feedback.service.ts
@@ -1,0 +1,62 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+import type { RequestUser } from '../auth/auth.types';
+import { EmailService } from '../email/email.service';
+
+import { CreateFeedbackDto } from './dto/create-feedback.dto';
+
+/**
+ * フィードバックを管理者へ届けるサービス。
+ * 既存のメール基盤（EmailService / Resend）を再利用し、ADMIN_EMAIL 宛にメール送信する。
+ * DB には保存しない（メール送信のみ）。
+ */
+@Injectable()
+export class FeedbackService {
+  private readonly logger = new Logger(FeedbackService.name);
+
+  constructor(
+    private readonly emailService: EmailService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  async submit(dto: CreateFeedbackDto, user?: RequestUser): Promise<{ sent: boolean }> {
+    const adminEmail = this.configService.get<string>('ADMIN_EMAIL');
+    if (!adminEmail) {
+      this.logger.error('ADMIN_EMAIL が未設定のため、フィードバックメールを送信できません。');
+      return { sent: false };
+    }
+
+    const senderLabel = user?.email ?? '不明なユーザー';
+    const result = await this.emailService.sendEmail({
+      to: adminEmail,
+      replyTo: user?.email,
+      subject: '[MyCats Pro] フィードバックが届きました',
+      html: `
+        <p>アプリ利用者からフィードバックが届きました。</p>
+        <p><strong>送信者:</strong> ${this.escapeHtml(senderLabel)}</p>
+        <hr />
+        <p style="white-space: pre-wrap;">${this.escapeHtml(dto.message)}</p>
+      `,
+      text: `フィードバック (送信者: ${senderLabel})\n\n${dto.message}`,
+    });
+
+    if (!result.success) {
+      this.logger.warn(
+        'フィードバックメールの送信に失敗しました（RESEND_API_KEY / EMAIL_FROM などの設定を確認してください）。',
+      );
+    }
+
+    return { sent: result.success };
+  }
+
+  /** メール本文に埋め込む前にユーザー入力をエスケープする */
+  private escapeHtml(value: string): string {
+    return value
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+}

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -53,6 +53,7 @@ import { useBottomNavSettings } from '@/lib/hooks/use-bottom-nav-settings';
 import { useOnboardingStore } from '@/lib/store/onboarding-store';
 import { findPageGuide } from '@/lib/onboarding/page-guides';
 import { PageOnboardingHost } from '@/components/onboarding/PageOnboardingHost';
+import { FeedbackWidget } from '@/components/feedback/FeedbackWidget';
 
 import type { Permission } from '@/lib/auth/permissions';
 
@@ -577,6 +578,7 @@ export function AppLayout({ children }: AppLayoutProps) {
         </AppShell>
       </ContextMenuManager>
       <PageOnboardingHost />
+      <FeedbackWidget />
     </div>
   );
 }

--- a/frontend/src/components/feedback/FeedbackWidget.tsx
+++ b/frontend/src/components/feedback/FeedbackWidget.tsx
@@ -1,0 +1,225 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { ActionIcon, Button, Group, Modal, Stack, Text, Textarea, Tooltip } from '@mantine/core';
+import { IconMail } from '@tabler/icons-react';
+import { notifications } from '@mantine/notifications';
+import { submitFeedback } from '@/lib/api/feedback';
+
+const POSITION_KEY = 'feedback-widget-position';
+const MAX_LENGTH = 200;
+const DRAG_THRESHOLD = 5; // この距離を超えて動いたらドラッグと判定（クリックと区別）
+const BUTTON_SIZE = 52;
+
+interface Position {
+  x: number;
+  y: number;
+}
+
+/** ボタンが画面外に出ないように位置を制限する */
+function clampToViewport(pos: Position): Position {
+  if (typeof window === 'undefined') return pos;
+  const maxX = Math.max(0, window.innerWidth - BUTTON_SIZE);
+  const maxY = Math.max(0, window.innerHeight - BUTTON_SIZE);
+  return {
+    x: Math.min(Math.max(0, pos.x), maxX),
+    y: Math.min(Math.max(0, pos.y), maxY),
+  };
+}
+
+/**
+ * 常駐のフィードバック手紙アイコン。
+ * - ドラッグで位置を移動でき、位置は localStorage に保存される
+ * - クリック（ドラッグでない）でフィードバックモーダルを開く
+ * - 送信で /feedback（管理者宛メール）に届く
+ */
+export function FeedbackWidget() {
+  const [position, setPosition] = useState<Position | null>(null);
+  const [opened, setOpened] = useState(false);
+  const [message, setMessage] = useState('');
+  const [sending, setSending] = useState(false);
+
+  const positionRef = useRef<Position | null>(null);
+  const dragStartRef = useRef<{ pointerX: number; pointerY: number; x: number; y: number } | null>(null);
+  const movedRef = useRef(false);
+
+  // 初期位置（localStorage か既定値=右下）を復元
+  useEffect(() => {
+    let initial: Position | null = null;
+    try {
+      const stored = localStorage.getItem(POSITION_KEY);
+      if (stored) {
+        const parsed = JSON.parse(stored) as Partial<Position>;
+        if (typeof parsed.x === 'number' && typeof parsed.y === 'number') {
+          initial = { x: parsed.x, y: parsed.y };
+        }
+      }
+    } catch {
+      // ignore
+    }
+    if (!initial) {
+      initial = {
+        x: window.innerWidth - BUTTON_SIZE - 20,
+        y: window.innerHeight - BUTTON_SIZE - 150,
+      };
+    }
+    const clamped = clampToViewport(initial);
+    positionRef.current = clamped;
+    setPosition(clamped);
+  }, []);
+
+  // リサイズ時に画面内へ収める
+  useEffect(() => {
+    const onResize = () => {
+      setPosition((prev) => {
+        if (!prev) return prev;
+        const clamped = clampToViewport(prev);
+        positionRef.current = clamped;
+        return clamped;
+      });
+    };
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
+
+  const handlePointerDown = useCallback((e: React.PointerEvent<HTMLButtonElement>) => {
+    const pos = positionRef.current;
+    if (!pos) return;
+    e.currentTarget.setPointerCapture(e.pointerId);
+    dragStartRef.current = { pointerX: e.clientX, pointerY: e.clientY, x: pos.x, y: pos.y };
+    movedRef.current = false;
+  }, []);
+
+  const handlePointerMove = useCallback((e: React.PointerEvent<HTMLButtonElement>) => {
+    const start = dragStartRef.current;
+    if (!start) return;
+    const dx = e.clientX - start.pointerX;
+    const dy = e.clientY - start.pointerY;
+    if (!movedRef.current && Math.hypot(dx, dy) > DRAG_THRESHOLD) {
+      movedRef.current = true;
+    }
+    if (movedRef.current) {
+      const next = clampToViewport({ x: start.x + dx, y: start.y + dy });
+      positionRef.current = next;
+      setPosition(next);
+    }
+  }, []);
+
+  const handlePointerUp = useCallback((e: React.PointerEvent<HTMLButtonElement>) => {
+    const start = dragStartRef.current;
+    dragStartRef.current = null;
+    if (!start) return;
+    if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+      e.currentTarget.releasePointerCapture(e.pointerId);
+    }
+    if (movedRef.current) {
+      // ドラッグ終了 → 位置を保存
+      try {
+        if (positionRef.current) {
+          localStorage.setItem(POSITION_KEY, JSON.stringify(positionRef.current));
+        }
+      } catch {
+        // ignore
+      }
+    } else {
+      // クリック → モーダルを開く
+      setOpened(true);
+    }
+  }, []);
+
+  const handleClose = useCallback(() => {
+    if (sending) return;
+    setOpened(false);
+  }, [sending]);
+
+  const handleSend = useCallback(async () => {
+    const trimmed = message.trim();
+    if (!trimmed) return;
+    setSending(true);
+    try {
+      const { sent } = await submitFeedback(trimmed);
+      notifications.show({
+        title: sent ? 'フィードバックを送信しました' : 'フィードバックを受け付けました',
+        message: sent
+          ? 'ご意見ありがとうございます！'
+          : 'ありがとうございます。送信は受け付けましたが、配信設定により届かない場合があります。',
+        color: sent ? 'teal' : 'yellow',
+      });
+      setMessage('');
+      setOpened(false);
+    } catch {
+      notifications.show({
+        title: 'エラー',
+        message: 'フィードバックの送信に失敗しました。時間をおいて再度お試しください。',
+        color: 'red',
+      });
+    } finally {
+      setSending(false);
+    }
+  }, [message]);
+
+  if (!position) return null;
+
+  return (
+    <>
+      <Tooltip label="フィードバックを送る" withArrow position="left">
+        <ActionIcon
+          variant="filled"
+          color="blue"
+          radius="xl"
+          size={BUTTON_SIZE}
+          aria-label="フィードバックを送る"
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          data-testid="feedback-widget-button"
+          style={{
+            position: 'fixed',
+            left: position.x,
+            top: position.y,
+            zIndex: 150,
+            touchAction: 'none',
+            cursor: 'grab',
+            boxShadow: '0 6px 18px rgba(0, 0, 0, 0.2)',
+          }}
+        >
+          <IconMail size={24} />
+        </ActionIcon>
+      </Tooltip>
+
+      <Modal opened={opened} onClose={handleClose} title="フィードバック" centered data-testid="feedback-modal">
+        <Stack gap="sm">
+          <Text size="sm" c="dimmed">
+            ご意見・ご要望をお聞かせください（最大{MAX_LENGTH}文字）。
+          </Text>
+          <Textarea
+            value={message}
+            onChange={(e) => setMessage(e.currentTarget.value.slice(0, MAX_LENGTH))}
+            maxLength={MAX_LENGTH}
+            minRows={4}
+            autosize
+            placeholder="気づいたこと・改善してほしいことなど"
+            data-autofocus
+            data-testid="feedback-textarea"
+          />
+          <Text size="xs" c="dimmed" ta="right">
+            {message.length} / {MAX_LENGTH}
+          </Text>
+          <Group justify="flex-end" gap="sm">
+            <Button variant="default" onClick={handleClose} disabled={sending}>
+              キャンセル
+            </Button>
+            <Button
+              onClick={handleSend}
+              loading={sending}
+              disabled={!message.trim()}
+              data-testid="feedback-send"
+            >
+              送信
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
+    </>
+  );
+}

--- a/frontend/src/lib/api/feedback.ts
+++ b/frontend/src/lib/api/feedback.ts
@@ -1,0 +1,34 @@
+import { getAccessToken } from './client';
+import { getPublicApiBaseUrl } from './public-api-base-url';
+
+/**
+ * フィードバックを送信する。
+ *
+ * `/feedback` は生成済み OpenAPI スキーマに含まれない新規エンドポイントのため、
+ * 厳格型付けの apiClient ではなく、認証トークンを付与した薄い fetch ラッパーで呼び出す。
+ *
+ * @returns sent: 管理者へのメール送信に成功したか（サーバー設定により false の場合がある）
+ */
+export async function submitFeedback(message: string): Promise<{ sent: boolean }> {
+  const token = getAccessToken();
+  const response = await fetch(`${getPublicApiBaseUrl()}/feedback`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify({ message }),
+    credentials: 'include',
+  });
+
+  if (!response.ok) {
+    throw new Error('フィードバックの送信に失敗しました');
+  }
+
+  const json: unknown = await response.json().catch(() => null);
+  const sent =
+    typeof json === 'object' && json !== null && 'data' in json
+      ? Boolean((json as { data?: { sent?: boolean } }).data?.sent)
+      : false;
+  return { sent };
+}


### PR DESCRIPTION
## 概要

常駐の手紙アイコンから、利用者がフィードバックを送れる機能を追加します。送信すると管理者（アプリ所有者）へメールで届きます。

## できること

- 画面に**常駐する手紙アイコン**（フローティング）。**ドラッグで自由に移動**でき、位置は localStorage に保存。
- クリックすると**フィードバックモーダル**（最大200文字、文字数カウンタ付き）が開く。
- 「送信」で `POST /api/v1/feedback` → **管理者宛にメール送信**。

## 実装（メール送信のみ・DB保存なし・マイグレーション不要）

- **backend**: `feedback` モジュールを新設（`POST /api/v1/feedback`、JWT 認証）。既存の **`EmailService`（Resend）を再利用**し `ADMIN_EMAIL` 宛に送信。送信者のメールも本文・replyTo に含める。HTML はエスケープ。
- **frontend**: `FeedbackWidget`（ドラッグ可能な常駐ボタン＋モーダル）を `AppLayout` に常駐。`/feedback` は生成 OpenAPI スキーマ外のため、認証トークン付きの薄い fetch ヘルパー（`src/lib/api/feedback.ts`）で呼び出し。

## 設定（運用時）

- 送信先は環境変数 **`ADMIN_EMAIL`**（既存・env validation 済み）。
- 実際の送信には **`RESEND_API_KEY`** の設定が必要（招待・パスワードリセットと同じ基盤）。未設定の場合は送信されず、UI には「受け付けたが配信設定により届かない場合がある」旨を表示。

## 検証

- 実ブラウザ（Playwright）で確認: ボタン表示／**ドラッグ移動＆位置保存**／**200字で頭打ち**／送信で `/feedback` に POST されモーダルが閉じる／pageerror なし。
- `backend build`（`nest build`）グリーン、frontend `型チェック`／`eslint --max-warnings 0`／`next build`（全26ページ生成）グリーン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)